### PR TITLE
[FEAT] ReviewRepository 생성 및 강좌 별 리뷰 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/projectlxp/review/repository/ReviewRepository.java
+++ b/src/main/java/com/example/projectlxp/review/repository/ReviewRepository.java
@@ -1,0 +1,21 @@
+package com.example.projectlxp.review.repository;
+
+import com.example.projectlxp.course.entity.Course;
+import com.example.projectlxp.review.entity.Review;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+    /**
+     * 특정 강좌(Course)에 해당하는 리뷰 목록을 페이징 처리하여 조회.
+     * Pageable 객체에 담긴 정렬(sort) 및 페이징(page, size) 정보를 바탕으로
+     * JPA가 자동으로 쿼리를 생성.
+     *
+     * @param course 조회할 강좌 엔티티
+     * @param pageable 페이징 및 정렬 정보
+     * @return 페이징 처리된 리뷰 목록 (Page<Review>)
+     */
+    Page<Review> findByCourse(Course course, Pageable pageable);
+}


### PR DESCRIPTION

## ❗️ 이슈 번호
Closes #8 

## 📝 작업 내용
JpaRepository를 상속받아 Review 엔티티의 CRUD를 관리하는 ReviewRepository 인터페이스를 생성했습니다.
API 요구사항인 강좌 별 리뷰 조회 및 정렬/ 페이징을 지원하기 위해 Pageable을 활용한 findByCourse 쿼리 메서드를 정의했습니다.
## 💭 주의 사항
Pageable 객체를 import할 때, org.springframework.data.domain.Pageable을 정확하게 import해야 합니다.
## 💡 리뷰 포인트
findByCourse 쿼리 메서드가 #8번 이슈의 요구사항(페이징, 정렬)을 올바르게 만족하는지 확인 부탁드립니다.

