### PR TITLE
[FEAT] 섹션 생성 API 구현

### DIFF
--- a/src/main/java/com/example/projectlxp/section/controller/SectionController.java
+++ b/src/main/java/com/example/projectlxp/section/controller/SectionController.java
@@ -1,0 +1,43 @@
+package com.example.projectlxp.section.controller;
+
+import jakarta.validation.Valid;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.projectlxp.global.dto.BaseResponse;
+import com.example.projectlxp.section.controller.dto.request.SectionCreateRequestDTO;
+import com.example.projectlxp.section.controller.dto.response.SectionCreateResponseDTO;
+import com.example.projectlxp.section.service.SectionService;
+
+@RestController
+@RequestMapping(value = "/sections")
+public class SectionController {
+
+    private final SectionService sectionService;
+
+    @Autowired
+    public SectionController(SectionService sectionService) {
+        this.sectionService = sectionService;
+    }
+
+    @PostMapping
+    public BaseResponse<SectionCreateResponseDTO> createSection(
+            @RequestBody @Valid SectionCreateRequestDTO request) {
+        try {
+            SectionCreateResponseDTO createdSection =
+                    sectionService.registerSection(
+                            request.courseId, request.title, request.orderNo);
+
+            return new BaseResponse<>(HttpStatus.CREATED, "Created Section.", createdSection);
+        } catch (IllegalArgumentException e) {
+            return BaseResponse.error(HttpStatus.NOT_FOUND, "Course를 찾을 수 없습니다.");
+        } catch (IllegalStateException e) {
+            return BaseResponse.error(HttpStatus.BAD_REQUEST, "Section의 순서가 동일합니다.");
+        }
+    }
+}

--- a/src/main/java/com/example/projectlxp/section/controller/dto/request/SectionCreateRequestDTO.java
+++ b/src/main/java/com/example/projectlxp/section/controller/dto/request/SectionCreateRequestDTO.java
@@ -1,0 +1,22 @@
+package com.example.projectlxp.section.controller.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public class SectionCreateRequestDTO {
+
+    @NotNull(message = "course ID는 필수 입력 값 입니다.")
+    public Long courseId;
+
+    @NotBlank(message = "섹션의 제목을 입력해주세요.")
+    public String title;
+
+    @NotNull(message = "order No는 필수 입력 값 입니다.")
+    public int orderNo;
+
+    public SectionCreateRequestDTO(Long courseId, String title, int orderNo) {
+        this.courseId = courseId;
+        this.title = title;
+        this.orderNo = orderNo;
+    }
+}

--- a/src/main/java/com/example/projectlxp/section/controller/dto/response/SectionCreateResponseDTO.java
+++ b/src/main/java/com/example/projectlxp/section/controller/dto/response/SectionCreateResponseDTO.java
@@ -1,0 +1,25 @@
+package com.example.projectlxp.section.controller.dto.response;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import lombok.Getter;
+
+@Getter
+public class SectionCreateResponseDTO {
+
+    @NotNull(message = "Section의 ID 값은 필수 입니다.")
+    private Long sectionId;
+
+    @NotBlank(message = "섹션의 제목은 빈값이 안됩니다.")
+    private String title;
+
+    @NotNull(message = "섹션의 순서는 필수 입니다.")
+    private int orderNo;
+
+    public SectionCreateResponseDTO(Long sectionId, String title, int orderNo) {
+        this.sectionId = sectionId;
+        this.title = title;
+        this.orderNo = orderNo;
+    }
+}

--- a/src/main/java/com/example/projectlxp/section/entity/Section.java
+++ b/src/main/java/com/example/projectlxp/section/entity/Section.java
@@ -54,4 +54,15 @@ public class Section extends BaseEntity {
 
     @OneToMany(mappedBy = "section")
     private List<Lecture> lectures = new ArrayList<>();
+
+    // Factory Method Pattern
+    private Section(Course course, String title, int orderNo) {
+        this.course = course;
+        this.title = title;
+        this.orderNo = orderNo;
+    }
+
+    public static Section createSection(Course course, String title, int orderNo) {
+        return new Section(course, title, orderNo);
+    }
 }

--- a/src/main/java/com/example/projectlxp/section/repository/SectionRepository.java
+++ b/src/main/java/com/example/projectlxp/section/repository/SectionRepository.java
@@ -1,9 +1,14 @@
 package com.example.projectlxp.section.repository;
 
-import com.example.projectlxp.section.entity.Section;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import com.example.projectlxp.section.entity.Section;
+
 @Repository
 public interface SectionRepository extends JpaRepository<Section, Long> {
+
+    Optional<Section> findByCourseIdAndOrderNo(Long courseId, int orderNo);
 }

--- a/src/main/java/com/example/projectlxp/section/service/SectionService.java
+++ b/src/main/java/com/example/projectlxp/section/service/SectionService.java
@@ -1,0 +1,16 @@
+package com.example.projectlxp.section.service;
+
+import com.example.projectlxp.section.controller.dto.response.SectionCreateResponseDTO;
+
+public interface SectionService {
+
+    /**
+     * 섹션을 생성합니다.
+     *
+     * @param courseId 강좌(course)의 ID값
+     * @param title 섹션의 제목
+     * @param orderNo 섹션의 순서
+     * @return SectionCreateResponseDTO
+     */
+    public SectionCreateResponseDTO registerSection(Long courseId, String title, int orderNo);
+}

--- a/src/main/java/com/example/projectlxp/section/service/impl/SectionServiceImpl.java
+++ b/src/main/java/com/example/projectlxp/section/service/impl/SectionServiceImpl.java
@@ -1,0 +1,60 @@
+package com.example.projectlxp.section.service.impl;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.projectlxp.course.entity.Course;
+import com.example.projectlxp.course.repository.CourseRepository;
+import com.example.projectlxp.section.controller.dto.response.SectionCreateResponseDTO;
+import com.example.projectlxp.section.entity.Section;
+import com.example.projectlxp.section.repository.SectionRepository;
+import com.example.projectlxp.section.service.SectionService;
+
+@Service
+public class SectionServiceImpl implements SectionService {
+
+    private final SectionRepository sectionRepository;
+    private final CourseRepository courseRespository;
+
+    @Autowired
+    public SectionServiceImpl(
+            SectionRepository sectionRepository, CourseRepository courseRespository) {
+        this.sectionRepository = sectionRepository;
+        this.courseRespository = courseRespository;
+    }
+
+    @Override
+    @Transactional
+    public SectionCreateResponseDTO registerSection(Long courseId, String title, int orderNo) {
+        // TODO : IllegalArgumentException으로 하려고 하니 Controller에서 Catch 분리를 어떻게 해야할지 모르겠음 !
+
+        // find Course By id
+        Course findCourse =
+                courseRespository
+                        .findById(courseId)
+                        .orElseThrow(() -> new IllegalArgumentException("Course를 찾을 수 없습니다."));
+
+        // check section by courseId & orderNo
+        Section findedSection =
+                sectionRepository.findByCourseIdAndOrderNo(courseId, orderNo).orElse(null);
+
+        if (findedSection != null) {
+            throw new IllegalStateException("동일한 순서로 Section을 생성하고 있습니다.");
+        }
+
+        // create Section
+        Section newSection = Section.createSection(findCourse, title, orderNo);
+
+        // save Section
+        Section savedSection = sectionRepository.save(newSection);
+
+        // convert To SectionCreateResponseDTO
+        SectionCreateResponseDTO response;
+        response =
+                new SectionCreateResponseDTO(
+                        savedSection.getId(), savedSection.getTitle(), savedSection.getOrderNo());
+
+        return response;
+    }
+}

--- a/src/main/java/com/example/projectlxp/section/service/impl/SectionServiceImpl.java
+++ b/src/main/java/com/example/projectlxp/section/service/impl/SectionServiceImpl.java
@@ -35,13 +35,13 @@ public class SectionServiceImpl implements SectionService {
                         .findById(courseId)
                         .orElseThrow(() -> new IllegalArgumentException("Course를 찾을 수 없습니다."));
 
-        // check section by courseId & orderNo
-        Section findedSection =
-                sectionRepository.findByCourseIdAndOrderNo(courseId, orderNo).orElse(null);
-
-        if (findedSection != null) {
-            throw new IllegalStateException("동일한 순서로 Section을 생성하고 있습니다.");
-        }
+        // check section by courseId & orderNo유
+        sectionRepository
+                .findByCourseIdAndOrderNo(courseId, orderNo)
+                .ifPresent(
+                        section -> {
+                            throw new IllegalStateException("동일한 순서로 Section을 생성하고 있습니다.");
+                        });
 
         // create Section
         Section newSection = Section.createSection(findCourse, title, orderNo);

--- a/src/main/java/com/example/projectlxp/section/service/impl/SectionServiceImpl.java
+++ b/src/main/java/com/example/projectlxp/section/service/impl/SectionServiceImpl.java
@@ -35,7 +35,7 @@ public class SectionServiceImpl implements SectionService {
                         .findById(courseId)
                         .orElseThrow(() -> new IllegalArgumentException("Course를 찾을 수 없습니다."));
 
-        // check section by courseId & orderNo유
+        // check section by courseId & orderNo
         sectionRepository
                 .findByCourseIdAndOrderNo(courseId, orderNo)
                 .ifPresent(


### PR DESCRIPTION
## ❗️ 이슈 번호
#11 

## 📝 작업 내용
**1. SectionService 인터페이스, SectionServiceImpl 구현체**
- 구현체 내부에 registerSection 메서드를 정의하여 비즈니스 로직을 만들었습니다.
- **Course가 없는 경우**, Section에 **동일한 course_id, order_no를 가질 경우** throw를 반환하도록 하였습니다.
- Controller로 넘기기 전에 **SectionCreateResponseDTO로 변환**하여 return했습니다.

**2. ResponseDTO, RequestDTO**
- **Validation 어노테이션을 사용**하여 필수 요청, 응답 데이터를 관리했습니다.
- 응답 시 `@Getter`어노테이션을 사용하여 **직렬화 문제를 해결**하였습니다.

**3 . SectionController**
- SectionService에서 응답 받은 값을 **BaseResponse의 Data에 넣어 응답**하였습니다
- Try Catch 구문을 사용하여 **Service에서 발생한 throw를 받아 응답**하도록 구현하였습니다.

**4. SectionRepository**
- Section생성 시 동일한 **course_id와 order_no를 가지는 값이 있는지 확인**하는 findByCourseIdAndOrderNo를 정의하였습니다.

## 💭 주의 사항

## 💡 리뷰 포인트
1. SectionService에서 IllegalArgumentException, IllegalStateException으로 나눠서 오류 처리를 구분하였는데 다른 방법이 있을까요 ?
2. controller에서 CREATE(201), NOT_FOUND(404), BAD_REQUEST(400)으로 구분했는데 postman에서는 동일하게 200으로 반환되는 것 같은데 상관 없을까요 ? (응답 메시지의 'status' 필드는 201, 404, 400으로 표기되어있기는 합니다 !

<img width="1004" height="329" alt="image" src="https://github.com/user-attachments/assets/c173226b-f070-4d65-9779-5e87c9ba9c8b" />
<img width="1007" height="329" alt="image" src="https://github.com/user-attachments/assets/a35e878a-b844-4f9b-9c0b-087e1097d2f0" />
<img width="1008" height="329" alt="image" src="https://github.com/user-attachments/assets/8de6ce52-3722-4cae-ab8c-eb856952fa8c" />
