### PR TITLE
[FEAT] 섹션 업데이트 API 구현

### DIFF
--- a/src/main/java/com/example/projectlxp/section/controller/SectionController.java
+++ b/src/main/java/com/example/projectlxp/section/controller/SectionController.java
@@ -32,31 +32,20 @@ public class SectionController {
     @PostMapping
     public BaseResponse<SectionCreateResponseDTO> createSection(
             @RequestBody @Valid SectionCreateRequestDTO request) {
-        try {
-            SectionCreateResponseDTO createdSection =
-                    sectionService.registerSection(
-                            request.courseId, request.title, request.orderNo);
+        SectionCreateResponseDTO createdSection =
+                sectionService.registerSection(request.courseId, request.title, request.orderNo);
 
-            return new BaseResponse<>(HttpStatus.CREATED, "Created Section.", createdSection);
-        } catch (IllegalArgumentException e) {
-            return BaseResponse.error(HttpStatus.NOT_FOUND, "Course를 찾을 수 없습니다.");
-        } catch (IllegalStateException e) {
-            return BaseResponse.error(HttpStatus.BAD_REQUEST, "Section의 순서가 동일합니다.");
-        }
+        return new BaseResponse<>(HttpStatus.CREATED, "Created Section.", createdSection);
     }
 
     @PutMapping("/{sectionId}")
     public BaseResponse<SectionUpdateResponseDTO> updateSection(
             @PathVariable(name = "sectionId") Long sectionId,
             @RequestBody @Valid SectionUpdateRequestDTO request) {
-        try {
-            SectionUpdateResponseDTO updatedSection =
-                    sectionService.modifySection(sectionId, request.title, request.orderNo);
 
-            return BaseResponse.success(updatedSection);
+        SectionUpdateResponseDTO updatedSection =
+                sectionService.modifySection(sectionId, request.title, request.orderNo);
 
-        } catch (IllegalArgumentException e) {
-            return BaseResponse.error(HttpStatus.BAD_REQUEST, "존재하지 않는 Section입니다.");
-        }
+        return BaseResponse.success(updatedSection);
     }
 }

--- a/src/main/java/com/example/projectlxp/section/controller/SectionController.java
+++ b/src/main/java/com/example/projectlxp/section/controller/SectionController.java
@@ -4,14 +4,18 @@ import jakarta.validation.Valid;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.projectlxp.global.dto.BaseResponse;
 import com.example.projectlxp.section.controller.dto.request.SectionCreateRequestDTO;
+import com.example.projectlxp.section.controller.dto.request.SectionUpdateRequestDTO;
 import com.example.projectlxp.section.controller.dto.response.SectionCreateResponseDTO;
+import com.example.projectlxp.section.controller.dto.response.SectionUpdateResponseDTO;
 import com.example.projectlxp.section.service.SectionService;
 
 @RestController
@@ -38,6 +42,21 @@ public class SectionController {
             return BaseResponse.error(HttpStatus.NOT_FOUND, "Course를 찾을 수 없습니다.");
         } catch (IllegalStateException e) {
             return BaseResponse.error(HttpStatus.BAD_REQUEST, "Section의 순서가 동일합니다.");
+        }
+    }
+
+    @PutMapping("/{sectionId}")
+    public BaseResponse<SectionUpdateResponseDTO> updateSection(
+            @PathVariable(name = "sectionId") Long sectionId,
+            @RequestBody @Valid SectionUpdateRequestDTO request) {
+        try {
+            SectionUpdateResponseDTO updatedSection =
+                    sectionService.modifySection(sectionId, request.title, request.orderNo);
+
+            return BaseResponse.success(updatedSection);
+
+        } catch (IllegalArgumentException e) {
+            return BaseResponse.error(HttpStatus.BAD_REQUEST, "존재하지 않는 Section입니다.");
         }
     }
 }

--- a/src/main/java/com/example/projectlxp/section/controller/dto/request/SectionUpdateRequestDTO.java
+++ b/src/main/java/com/example/projectlxp/section/controller/dto/request/SectionUpdateRequestDTO.java
@@ -1,0 +1,13 @@
+package com.example.projectlxp.section.controller.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public class SectionUpdateRequestDTO {
+
+    @NotBlank(message = "섹션의 제목을 입력해주세요.")
+    public String title;
+
+    @NotNull(message = "order No는 필수 입력 값 입니다.")
+    public int orderNo;
+}

--- a/src/main/java/com/example/projectlxp/section/controller/dto/response/SectionCreateResponseDTO.java
+++ b/src/main/java/com/example/projectlxp/section/controller/dto/response/SectionCreateResponseDTO.java
@@ -1,20 +1,14 @@
 package com.example.projectlxp.section.controller.dto.response;
 
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-
 import lombok.Getter;
 
 @Getter
 public class SectionCreateResponseDTO {
 
-    @NotNull(message = "Section의 ID 값은 필수 입니다.")
     private Long sectionId;
 
-    @NotBlank(message = "섹션의 제목은 빈값이 안됩니다.")
     private String title;
 
-    @NotNull(message = "섹션의 순서는 필수 입니다.")
     private int orderNo;
 
     public SectionCreateResponseDTO(Long sectionId, String title, int orderNo) {

--- a/src/main/java/com/example/projectlxp/section/controller/dto/response/SectionUpdateResponseDTO.java
+++ b/src/main/java/com/example/projectlxp/section/controller/dto/response/SectionUpdateResponseDTO.java
@@ -1,0 +1,25 @@
+package com.example.projectlxp.section.controller.dto.response;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import lombok.Getter;
+
+@Getter
+public class SectionUpdateResponseDTO {
+
+    @NotNull(message = "Section ID 값은 필수 입니다.")
+    public Long sectionId;
+
+    @NotBlank(message = "섹션의 제목을 입력해주세요.")
+    public String title;
+
+    @NotNull(message = "Order No 값은 필수 입니다.")
+    public int orderNo;
+
+    public SectionUpdateResponseDTO(Long sectionId, String title, int orderNo) {
+        this.sectionId = sectionId;
+        this.title = title;
+        this.orderNo = orderNo;
+    }
+}

--- a/src/main/java/com/example/projectlxp/section/controller/dto/response/SectionUpdateResponseDTO.java
+++ b/src/main/java/com/example/projectlxp/section/controller/dto/response/SectionUpdateResponseDTO.java
@@ -1,20 +1,14 @@
 package com.example.projectlxp.section.controller.dto.response;
 
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-
 import lombok.Getter;
 
 @Getter
 public class SectionUpdateResponseDTO {
 
-    @NotNull(message = "Section ID 값은 필수 입니다.")
     public Long sectionId;
 
-    @NotBlank(message = "섹션의 제목을 입력해주세요.")
     public String title;
 
-    @NotNull(message = "Order No 값은 필수 입니다.")
     public int orderNo;
 
     public SectionUpdateResponseDTO(Long sectionId, String title, int orderNo) {

--- a/src/main/java/com/example/projectlxp/section/entity/Section.java
+++ b/src/main/java/com/example/projectlxp/section/entity/Section.java
@@ -66,13 +66,9 @@ public class Section extends BaseEntity {
         return new Section(course, title, orderNo);
     }
 
-    // Setter
-
-    public void setTitle(String title) {
+    // Method
+    public void updateSection(String title, int orderNo) {
         this.title = title;
-    }
-
-    public void setOrderNo(int orderNo) {
         this.orderNo = orderNo;
     }
 }

--- a/src/main/java/com/example/projectlxp/section/entity/Section.java
+++ b/src/main/java/com/example/projectlxp/section/entity/Section.java
@@ -65,4 +65,14 @@ public class Section extends BaseEntity {
     public static Section createSection(Course course, String title, int orderNo) {
         return new Section(course, title, orderNo);
     }
+
+    // Setter
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public void setOrderNo(int orderNo) {
+        this.orderNo = orderNo;
+    }
 }

--- a/src/main/java/com/example/projectlxp/section/service/SectionService.java
+++ b/src/main/java/com/example/projectlxp/section/service/SectionService.java
@@ -13,7 +13,7 @@ public interface SectionService {
      * @param orderNo 섹션의 순서
      * @return SectionCreateResponseDTO
      */
-    public SectionCreateResponseDTO registerSection(Long courseId, String title, int orderNo);
+    SectionCreateResponseDTO registerSection(Long courseId, String title, int orderNo);
 
     /**
      * 섹션을 업데이트 합니다.
@@ -23,5 +23,5 @@ public interface SectionService {
      * @param orderNo 섹션의 순서
      * @return SectionUpdateResponseDTO
      */
-    public SectionUpdateResponseDTO modifySection(Long sectionId, String title, int orderNo);
+    SectionUpdateResponseDTO modifySection(Long sectionId, String title, int orderNo);
 }

--- a/src/main/java/com/example/projectlxp/section/service/SectionService.java
+++ b/src/main/java/com/example/projectlxp/section/service/SectionService.java
@@ -1,6 +1,7 @@
 package com.example.projectlxp.section.service;
 
 import com.example.projectlxp.section.controller.dto.response.SectionCreateResponseDTO;
+import com.example.projectlxp.section.controller.dto.response.SectionUpdateResponseDTO;
 
 public interface SectionService {
 
@@ -13,4 +14,14 @@ public interface SectionService {
      * @return SectionCreateResponseDTO
      */
     public SectionCreateResponseDTO registerSection(Long courseId, String title, int orderNo);
+
+    /**
+     * 섹션을 업데이트 합니다.
+     *
+     * @param sectionId 섹션(Section)의 ID값
+     * @param title 섹션의 제목
+     * @param orderNo 섹션의 순서
+     * @return SectionUpdateResponseDTO
+     */
+    public SectionUpdateResponseDTO modifySection(Long sectionId, String title, int orderNo);
 }

--- a/src/main/java/com/example/projectlxp/section/service/impl/SectionServiceImpl.java
+++ b/src/main/java/com/example/projectlxp/section/service/impl/SectionServiceImpl.java
@@ -71,15 +71,9 @@ public class SectionServiceImpl implements SectionService {
                         .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 Section 입니다."));
 
         // update Section
-        findSection.setTitle(title);
-        findSection.setOrderNo(orderNo);
+        findSection.updateSection(title, orderNo);
 
-        // convert To SectionUpdateResponseDTO
-        SectionUpdateResponseDTO response;
-        response =
-                new SectionUpdateResponseDTO(
-                        findSection.getId(), findSection.getTitle(), findSection.getOrderNo());
-
-        return response;
+        // convert To SectionUpdateResponseDTO & return
+        return new SectionUpdateResponseDTO(findSection.getId(), " ", findSection.getOrderNo());
     }
 }

--- a/src/main/java/com/example/projectlxp/section/service/impl/SectionServiceImpl.java
+++ b/src/main/java/com/example/projectlxp/section/service/impl/SectionServiceImpl.java
@@ -74,6 +74,7 @@ public class SectionServiceImpl implements SectionService {
         findSection.updateSection(title, orderNo);
 
         // convert To SectionUpdateResponseDTO & return
-        return new SectionUpdateResponseDTO(findSection.getId(), " ", findSection.getOrderNo());
+        return new SectionUpdateResponseDTO(
+                findSection.getId(), findSection.getTitle(), findSection.getOrderNo());
     }
 }

--- a/src/main/java/com/example/projectlxp/section/service/impl/SectionServiceImpl.java
+++ b/src/main/java/com/example/projectlxp/section/service/impl/SectionServiceImpl.java
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.example.projectlxp.course.entity.Course;
 import com.example.projectlxp.course.repository.CourseRepository;
 import com.example.projectlxp.section.controller.dto.response.SectionCreateResponseDTO;
+import com.example.projectlxp.section.controller.dto.response.SectionUpdateResponseDTO;
 import com.example.projectlxp.section.entity.Section;
 import com.example.projectlxp.section.repository.SectionRepository;
 import com.example.projectlxp.section.service.SectionService;
@@ -54,6 +55,30 @@ public class SectionServiceImpl implements SectionService {
         response =
                 new SectionCreateResponseDTO(
                         savedSection.getId(), savedSection.getTitle(), savedSection.getOrderNo());
+
+        return response;
+    }
+
+    @Override
+    @Transactional
+    public SectionUpdateResponseDTO modifySection(Long sectionId, String title, int orderNo) {
+        // TODO : order No가 이미 존재하면, 이미 존재하는 orderNO를 변경해야 하나 ?!
+
+        // find Section By ID
+        Section findSection =
+                sectionRepository
+                        .findById(sectionId)
+                        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 Section 입니다."));
+
+        // update Section
+        findSection.setTitle(title);
+        findSection.setOrderNo(orderNo);
+
+        // convert To SectionUpdateResponseDTO
+        SectionUpdateResponseDTO response;
+        response =
+                new SectionUpdateResponseDTO(
+                        findSection.getId(), findSection.getTitle(), findSection.getOrderNo());
 
         return response;
     }


### PR DESCRIPTION
## ❗️ 이슈 번호
#26 

## 📝 작업 내용
**1. Section**
- Section의 정보를 업데이트 하기 위한 Setter 메서드 추가.
- title, orderNo 필드만 Setter 메서드로 제공.

**2. SectionController** 
- PathVariable로 SectionId를 받도록 구현하였습니다.
- 업데이트하고자 하는 title, orderNo를 Body값으로 받도록 구현하였습니다.
- HTTP post 메서드로 정의하였습니다.
- try catch 구문으로 존재하지 않는 Section을 업데이트 하는 경우 400에러를 발생하도록 구현하였습니다.

**3. SectionService, SectionServiceImpl**
- SectionService 인터페이스에 modifySection 메서드를 정의하였습니다.
- SectionServiceImpl에서 비즈니스 로직을 구현하였습니다.
- `@Transactional`을 이용하여 Section 객체의 변경이 일어나면 자동으로 업데이트 되도록 구현하였습니다.

**4. SectionUpdateRequestDTO, SectionUpdateResponseDTO**
- `@Validation`을 이용하여 요청에 필요한 필드들을 검증하였습니다.
- ResponseDTO에서는`@Getter`를 이용하여 직렬화되지 않는 문제를 해결하였습니다.

## 💭 주의 사항
1. 현재 title이랑 orderNo만 변경하는 로직이 구현되어있습니다. 
   1번 orderNo를 2번으로 변경하면 2번 orderNo를 가지고 있는 Section은 3번으로 넘어가는 로직은 아직 미구현 상태입니다. 

## 💡 리뷰 포인트
1. Service 부분에서 자동으로 업데이트 되도록 구현하였는데, 문제가 없는지 확인 부탁드립니다 !
2. 현재 OrderNo를 변경하는 경우 변경될 OrderNo를 +1해주도록 구현하면 해당 기능은 구현이 되는 건지 궁금합니다
