### PR TITLE
[FEAT] User 회원가입  Controller API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 
     // Database
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     runtimeOnly 'com.mysql:mysql-connector-j'
 
     // Lombok
@@ -44,8 +45,8 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     // Security
-    // implementation 'org.springframework.boot:spring-boot-starter-security'
-    // testImplementation 'org.springframework.security:spring-security-test'
+     implementation 'org.springframework.boot:spring-boot-starter-security'
+     testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('compileJava') {

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,11 @@ dependencies {
     // Security
      implementation 'org.springframework.boot:spring-boot-starter-security'
      testImplementation 'org.springframework.security:spring-security-test'
+
+    // JMT
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('compileJava') {

--- a/src/main/java/com/example/projectlxp/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/projectlxp/global/config/SecurityConfig.java
@@ -1,0 +1,36 @@
+package com.example.projectlxp.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    // 비밀번호 암호화 도구 (PasswordEncoder)를 Bean을 ㅗ등록
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    // 보안 규칙 설정
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.csrf(csrf -> csrf.disable()) // CSRF 보호 비활성화 (API서버)
+                .authorizeHttpRequests(
+                        authorize ->
+                                authorize
+                                        .requestMatchers("/api/join")
+                                        .permitAll() // 회원가입 경로는 누구나
+                                        .anyRequest()
+                                        .authenticated() // 그 외 모든 요청은 인증 필요
+                        );
+        return http.build(); // http 객체를 build() 해서 반환
+    }
+}

--- a/src/main/java/com/example/projectlxp/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/projectlxp/global/config/SecurityConfig.java
@@ -12,7 +12,7 @@ import org.springframework.security.web.SecurityFilterChain;
 @EnableWebSecurity
 public class SecurityConfig {
 
-    // 비밀번호 암호화 도구 (PasswordEncoder)를 Bean을 ㅗ등록
+    // 비밀번호 암호화 도구 (PasswordEncoder)를 Bean으로 등록
 
     @Bean
     public PasswordEncoder passwordEncoder() {

--- a/src/main/java/com/example/projectlxp/user/controller/UserController.java
+++ b/src/main/java/com/example/projectlxp/user/controller/UserController.java
@@ -1,0 +1,36 @@
+package com.example.projectlxp.user.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.projectlxp.user.dto.UserJoinRequestDTO;
+import com.example.projectlxp.user.service.UserService;
+
+import lombok.RequiredArgsConstructor;
+
+// todo restController로
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class UserController {
+
+    private final UserService userService;
+
+    /*
+     * 회원가입 API
+     * */
+    @PostMapping("/join")
+    public ResponseEntity<String> join(
+            // @RequestBody : Form 데이터가 아님 JSON 데이터를 DTO로 변환
+            // @valicated : DTO의 @NotBlack 등 유효성 검사 실행
+            @Validated @RequestBody UserJoinRequestDTO requestDTO) {
+
+        userService.join(requestDTO);
+
+        return ResponseEntity.ok("회원가입 되셨습니다.");
+    }
+}

--- a/src/main/java/com/example/projectlxp/user/controller/UserController.java
+++ b/src/main/java/com/example/projectlxp/user/controller/UserController.java
@@ -30,7 +30,6 @@ public class UserController {
             @Validated @RequestBody UserJoinRequestDTO requestDTO) {
 
         userService.join(requestDTO);
-
         return ResponseEntity.ok("회원가입 되셨습니다.");
     }
 }

--- a/src/main/java/com/example/projectlxp/user/dto/UserJoinRequestDTO.java
+++ b/src/main/java/com/example/projectlxp/user/dto/UserJoinRequestDTO.java
@@ -36,8 +36,12 @@ public class UserJoinRequestDTO {
 
     // "STUDENT" 또는 "INSTRUCTOR" 문자열로 받습니다.
     @NotBlank(message = "역할은 필수 항목입니다.")
-    private String role;
 
+    @Pattern(
+            regexp = "(?i)^(STUDENT|INSTRUCTOR)$",
+            message = "역할은 'STUDENT' 또는 'INSTRUCTOR'만 가능합니다."
+    )
+    private String role;
     private String profileImage;
 
     // -- Entity 변환 로직 (Service에서 사용) ---

--- a/src/main/java/com/example/projectlxp/user/dto/UserJoinRequestDTO.java
+++ b/src/main/java/com/example/projectlxp/user/dto/UserJoinRequestDTO.java
@@ -1,0 +1,60 @@
+package com.example.projectlxp.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import com.example.projectlxp.user.entity.Role;
+import com.example.projectlxp.user.entity.User;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@AllArgsConstructor
+@ToString(exclude = "password") // password 필드를 제외하고 toString()생성
+public class UserJoinRequestDTO {
+
+    @NotBlank(message = "이름은 필수 항목입니다.")
+    @Size(max = 20, message = "이름은 20자를 초과할 수 없습니다.")
+    private String userName;
+
+    @NotBlank(message = "이메일은 필수 항목입니다.")
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
+    private String email;
+
+    // 요구사항 : 6글자 이상 영문 소문자, 숫자 1개 이상 포함
+    @NotBlank(message = "비밀번호는 필수 항목입니다.")
+    @Pattern(
+            regexp = "^(?=.*[a-z])(?=.*\\d)[a-z\\d]{6,}$",
+            message = "비밀번호는 6자 이상이며, 영문 소문자와 숫자를 각각 1개 이상 포함해야 합니다.")
+    private String password;
+
+    // "STUDENT" 또는 "INSTRUCTOR" 문자열로 받습니다.
+    @NotBlank(message = "역할은 필수 항목입니다.")
+    private String role;
+
+    private String profileImage;
+
+    // -- Entity 변환 로직 (Service에서 사용) ---
+    public User toEntity(PasswordEncoder passwordEncoder) {
+        Role userRole;
+        try {
+            // "student" -> "STUDENT"
+            userRole = Role.valueOf(this.role.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("유효하지 않은 역할(Role)입니다.");
+        }
+
+        return User.createUser(
+                this.userName,
+                this.email,
+                passwordEncoder.encode(this.password), // [암호화]
+                userRole,
+                this.profileImage);
+    }
+}

--- a/src/main/java/com/example/projectlxp/user/entity/User.java
+++ b/src/main/java/com/example/projectlxp/user/entity/User.java
@@ -76,4 +76,9 @@ public class User extends BaseEntity {
         this.hashedPassword = hashedPassword;
         this.profileImage = profileImage;
     }
+
+    public static User createUser(
+            String name, String email, String hashedPassword, Role role, String profileImage) {
+        return new User(name, role, email, hashedPassword, profileImage);
+    }
 }

--- a/src/main/java/com/example/projectlxp/user/service/UserService.java
+++ b/src/main/java/com/example/projectlxp/user/service/UserService.java
@@ -10,6 +10,4 @@ public interface UserService {
      * */
 
     void join(UserJoinRequestDTO requestDTO);
-
-    // 로그인
 }

--- a/src/main/java/com/example/projectlxp/user/service/UserService.java
+++ b/src/main/java/com/example/projectlxp/user/service/UserService.java
@@ -1,0 +1,15 @@
+package com.example.projectlxp.user.service;
+
+import com.example.projectlxp.user.dto.UserJoinRequestDTO;
+
+public interface UserService {
+
+    /*
+     * 회원가입 비즈니스 로직
+     * @Param requestDTO 회원가입 요청 정보
+     * */
+
+    void join(UserJoinRequestDTO requestDTO);
+
+    // 로그인
+}

--- a/src/main/java/com/example/projectlxp/user/service/UserServiceImpl.java
+++ b/src/main/java/com/example/projectlxp/user/service/UserServiceImpl.java
@@ -1,0 +1,35 @@
+package com.example.projectlxp.user.service;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.projectlxp.user.dto.UserJoinRequestDTO;
+import com.example.projectlxp.user.entity.User;
+import com.example.projectlxp.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    @Transactional // DB에 데이터를 저장
+    public void join(UserJoinRequestDTO requestDTO) {
+
+        // -- 테스트 코드 ---
+
+        // 이메일 중복 체크
+        if (userRepository.findByEmail(requestDTO.getEmail()).isPresent()) {
+            throw new IllegalStateException("이미 가입된 이메일입니다.");
+        }
+
+        User newUser = requestDTO.toEntity(passwordEncoder);
+
+        userRepository.save(newUser);
+    }
+}

--- a/src/main/java/com/example/projectlxp/user/service/UserServiceImpl.java
+++ b/src/main/java/com/example/projectlxp/user/service/UserServiceImpl.java
@@ -1,5 +1,8 @@
 package com.example.projectlxp.user.service;
 
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,11 +15,12 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
-public class UserServiceImpl implements UserService {
+public class UserServiceImpl implements UserService, UserDetailsService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
 
+    // 회원가입
     @Override
     @Transactional // DB에 데이터를 저장
     public void join(UserJoinRequestDTO requestDTO) {
@@ -27,9 +31,35 @@ public class UserServiceImpl implements UserService {
         if (userRepository.findByEmail(requestDTO.getEmail()).isPresent()) {
             throw new IllegalStateException("이미 가입된 이메일입니다.");
         }
-
         User newUser = requestDTO.toEntity(passwordEncoder);
-
         userRepository.save(newUser);
+    }
+
+    // 로그인
+    /*
+     * spring Security가 로그인을 처리할 때 호출하는 메서드
+     * @param username (로그인 시도하는 ID, 여기서는 email)
+     * @return UserDetails (Spring Security가 사용하는 User정보)
+     * @throws UsernameNotFoundException
+     * */
+    @Override
+    @Transactional(readOnly = true)
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+
+        // ID 대신 email을 사용하여 , email로 User를 찾음
+        User user =
+                userRepository
+                        .findByEmail(username)
+                        .orElseThrow(
+                                () ->
+                                        new UsernameNotFoundException(
+                                                "해당 이메일을 찾을 수 없습니다:" + username));
+
+        // spring Security UserDetails 객체로 변환하여 반환
+        return org.springframework.security.core.userdetails.User.builder()
+                .username(user.getEmail()) // 로그인 ID
+                .password(user.getHashedPassword()) // DB에 저장된 암호화된 PW
+                .roles(user.getRole().name()) // 권한
+                .build();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,14 +1,5 @@
 spring:
-  datasource:
-    url: jdbc:mysql://localhost:3306/
-    username:
-    password:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-
-  jpa:
-    hibernate:
-      ddl-auto:
-    properties:
-       show_sql: true
-       format_sql: true'
-       dialect: org.hibernate.dialect.MySQLDialect
+  application:
+    name: LXP-Project
+  profiles:
+    active: local

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,14 @@
 spring:
-  application:
-    name: LXP-Project
-  profiles:
-    active: local
+  datasource:
+    url: jdbc:mysql://localhost:3306/
+    username:
+    password:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto:
+    properties:
+       show_sql: true
+       format_sql: true'
+       dialect: org.hibernate.dialect.MySQLDialect

--- a/src/test/java/com/example/projectlxp/user/service/UserServiceTest.java
+++ b/src/test/java/com/example/projectlxp/user/service/UserServiceTest.java
@@ -1,0 +1,58 @@
+package com.example.projectlxp.user.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import com.example.projectlxp.user.dto.UserJoinRequestDTO;
+import com.example.projectlxp.user.entity.User;
+import com.example.projectlxp.user.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class UserServiceTest {
+
+    @Mock private UserRepository userRepository;
+
+    @Mock private PasswordEncoder passwordEncoder;
+
+    @InjectMocks private UserServiceImpl userService;
+
+    @Test
+    @DisplayName("회원가입 성공")
+    void join_Success() {
+
+        UserJoinRequestDTO requestDTO =
+                new UserJoinRequestDTO(
+                        "testUser", "test@exmaple.com", "password123", "STUDENT", null);
+        // 2. Mock 객체 행동 정의 (가장 중요!)
+        // (1) "findByEmail이 호출되면, 결과 없음(Optional.empty)을 반환해라"
+        when(userRepository.findByEmail(requestDTO.getEmail())).thenReturn(Optional.empty());
+
+        // (2) "passwordEncoder.encode가 호출되면, 'encodedPW'라고 반환해라"
+        when(passwordEncoder.encode(requestDTO.getPassword())).thenReturn("encodedPW");
+
+        // (3) "userRepository.save가 호출되면, 그냥 User 객체를 반환해라"
+        // (User 엔티티의 toEntity/createUser 메서드가 필요함)
+        when(userRepository.save(any(User.class))).thenReturn(null); // (임시로 null 반환)
+
+        // when (무엇을 할 때)
+        // [테스트 대상 실행]
+        userService.join(requestDTO);
+
+        // then (결과는?)
+        // [검증]
+        // "userRepository.save()가 '정확히 1번' 호출되었는가?"
+        verify(userRepository, times(1)).save(any(User.class));
+    }
+}


### PR DESCRIPTION
[test] : user 회원가입 테스트 코드

<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->

## ❗️ 이슈 번호
#23 

## 📝 작업 내용
- User 회원가입 Controller API구현 하였습니다.
- securityconfig 추가 
- role 둘 중만 선택하게 강제 설정
- email 중복 일 시 예외처리 , 이름은 중복일 때 가입 가능테스트 
- 강사 , 수강생 가입 테스트  완료 

## 💭 주의 사항
```json
{
    "userName" : "고길동",
    "email": "test2@example.com",
    "password": "mypassword1234", // 6글자 이상, 영문 소문자 숫자를 각각 1개 이상 포함해야합니다.
    "role": "INSTRUCTOR" // STUDENT 또는 INSTRUCTOR 선택 
}
```
## 💡 리뷰 포인트
<img width="857" height="100" alt="image" src="https://github.com/user-attachments/assets/7ccd756b-8984-4562-a0c0-01b9e174eee5" />
<img width="1714" height="209" alt="image" src="https://github.com/user-attachments/assets/9a13faa0-8d6f-494f-9d06-62ad142f9c22" />


<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->
