### PR TITLE
[FEAT] 로그인 기능 구현 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 
     // Database
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     runtimeOnly 'com.mysql:mysql-connector-j'
 
     // Lombok
@@ -44,8 +45,8 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     // Security
-    implementation 'org.springframework.boot:spring-boot-starter-security'
-    testImplementation 'org.springframework.security:spring-security-test'
+     implementation 'org.springframework.boot:spring-boot-starter-security'
+     testImplementation 'org.springframework.security:spring-security-test'
 
     // JMT
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/src/main/java/com/example/projectlxp/global/config/CurrentUserArgumentResolver.java
+++ b/src/main/java/com/example/projectlxp/global/config/CurrentUserArgumentResolver.java
@@ -1,0 +1,51 @@
+package com.example.projectlxp.global.config;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    // Resolver 지원 여부 확인
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        // @CurrentUserID가 붙어있고, 타입이 Long일 때만 작동
+        return parameter.hasParameterAnnotation(CurrentUserId.class)
+                && parameter.getParameterType().equals(Long.class);
+    }
+
+    // 값 추출 및 주입
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavAndViewContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory)
+            throws Exception {
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return null;
+        }
+
+        /*
+         * JwtTokenProvider.getAuthentication()에서
+         * Principal에 Long userID를 직접 넣었으므로,
+         * (Object) principal을 (Long)으로 캐스팅하여 바로 반환합니다.
+         * */
+        Object principal = authentication.getPrincipal();
+
+        if (principal instanceof Long) {
+            return (Long) principal;
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/example/projectlxp/global/config/CurrentUserId.java
+++ b/src/main/java/com/example/projectlxp/global/config/CurrentUserId.java
@@ -1,0 +1,12 @@
+package com.example.projectlxp.global.config;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER) // 파라미터에만 붙일 수 있음
+@Retention(RetentionPolicy.RUNTIME) // 런타임 까지 어노테이션 정보 유지
+@Documented
+public @interface CurrentUserId {}

--- a/src/main/java/com/example/projectlxp/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/projectlxp/global/config/SecurityConfig.java
@@ -1,7 +1,12 @@
 package com.example.projectlxp.global.config;
 
+import jakarta.servlet.http.HttpServletResponse;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -24,29 +29,59 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http.csrf(csrf -> csrf.disable()) // CSRF 보호 비활성화 (API서버)
+                .formLogin(form -> form.disable())
+                .httpBasic(basic -> basic.disable())
 
                 // 세션 정책 추가 (API서버는 STATELESS 권장
                 .sessionManagement(
                         session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
-                // formLogin 설정추가 (로그인 처리)
-                .formLogin(
-                        form ->
-                                form
-                                        // Spring Security가 처리할 로그인 API 경로
-                                        .loginProcessingUrl("/api/login")
-                                        // 로그인 ID로 사용할 파라미터 이름
-                                        .usernameParameter("email")
-                                        // 로그인 API 누구나 접근허용
-                                        .permitAll())
+                // 인증/인가 실패 시 JSON 응답을 위한 핸들러 추가
+                .exceptionHandling(
+                        exception ->
+                                exception
+                                        // 인증 실패 401
+                                        .authenticationEntryPoint(
+                                                (request, response, authException) -> {
+                                                    response.setStatus(
+                                                            HttpServletResponse.SC_UNAUTHORIZED);
+                                                    response.setContentType(
+                                                            MediaType.APPLICATION_JSON_VALUE);
+                                                    response.setCharacterEncoding("UTF-8");
+                                                    // JSON 에러 메세지 반환
+                                                    response.getWriter()
+                                                            .write(
+                                                                    "{\"error\": \"인증이 필요합니다.\", \"status\" : 401}");
+                                                })
+                                        // 인가 실패 (403 Forbidden)
+                                        .accessDeniedHandler(
+                                                (request, response, accessDeniedException) -> {
+                                                    response.setStatus(
+                                                            HttpServletResponse.SC_FORBIDDEN);
+                                                    response.setContentType(
+                                                            MediaType
+                                                                    .APPLICATION_PROBLEM_JSON_VALUE);
+                                                    response.setCharacterEncoding("UTF-8");
+                                                    response.getWriter()
+                                                            .write(
+                                                                    "{\"error\" : \"권한이 없습니다.\", \"status\": 403}");
+                                                }))
                 .authorizeHttpRequests(
                         authorize ->
                                 authorize
-                                        .requestMatchers("/api/join", "/api/login")
-                                        .permitAll() // 회원가입 경로는 누구나
+                                        .requestMatchers("/join", "/login")
+                                        .permitAll() // 회원가입 로그인은 누구나
+                                        .requestMatchers("/me", "/update")
+                                        .authenticated() // 정보조회,수정은 인증필요
                                         .anyRequest()
                                         .authenticated() // 그 외 모든 요청은 인증 필요
                         );
         return http.build(); // http 객체를 build() 해서 반환
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(
+            AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
     }
 }

--- a/src/main/java/com/example/projectlxp/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/projectlxp/global/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -23,10 +24,25 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http.csrf(csrf -> csrf.disable()) // CSRF 보호 비활성화 (API서버)
+
+                // 세션 정책 추가 (API서버는 STATELESS 권장
+                .sessionManagement(
+                        session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+                // formLogin 설정추가 (로그인 처리)
+                .formLogin(
+                        form ->
+                                form
+                                        // Spring Security가 처리할 로그인 API 경로
+                                        .loginProcessingUrl("/api/login")
+                                        // 로그인 ID로 사용할 파라미터 이름
+                                        .usernameParameter("email")
+                                        // 로그인 API 누구나 접근허용
+                                        .permitAll())
                 .authorizeHttpRequests(
                         authorize ->
                                 authorize
-                                        .requestMatchers("/api/join")
+                                        .requestMatchers("/api/join", "/api/login")
                                         .permitAll() // 회원가입 경로는 누구나
                                         .anyRequest()
                                         .authenticated() // 그 외 모든 요청은 인증 필요

--- a/src/main/java/com/example/projectlxp/global/config/WebConfig.java
+++ b/src/main/java/com/example/projectlxp/global/config/WebConfig.java
@@ -1,0 +1,21 @@
+package com.example.projectlxp.global.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final CurrentUserArgumentResolver currentUserIdArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(currentUserIdArgumentResolver);
+    }
+}

--- a/src/main/java/com/example/projectlxp/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/projectlxp/global/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,57 @@
+package com.example.projectlxp.global.jwt;
+
+import java.io.IOException;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component // 빈으로 등록
+@RequiredArgsConstructor // final 필드 주입
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    // Authorization 이라는 이름의 헤더를 찾겠다.
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    public static final String AUTHORIZATION_HEADER_PREFIX = "Bearer ";
+
+    private final JwtTokenProvider jwtTokenProvider; // 공장주입
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String token = resolveToken(request);
+        if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
+
+            Authentication authentication = jwtTokenProvider.getAuthentication(token);
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    /*
+     * Request Header 에서 Authorization 키를 찾아 토큰을 추춫ㄹ하는 메서드
+     * */
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken)
+                && bearerToken.startsWith(AUTHORIZATION_HEADER_PREFIX)) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/example/projectlxp/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/projectlxp/global/jwt/JwtAuthenticationFilter.java
@@ -14,9 +14,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Component // 빈으로 등록
 @RequiredArgsConstructor // final 필드 주입
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
@@ -44,7 +42,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     /*
-     * Request Header 에서 Authorization 키를 찾아 토큰을 추춫ㄹ하는 메서드
+     * Request Header 에서 Authorization 키를 찾아 토큰을 추출하는 메서드
      * */
     private String resolveToken(HttpServletRequest request) {
         String bearerToken = request.getHeader(AUTHORIZATION_HEADER);

--- a/src/main/java/com/example/projectlxp/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/projectlxp/global/jwt/JwtTokenProvider.java
@@ -15,6 +15,8 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Component;
 
+import com.example.projectlxp.user.dto.CustomUserDetails;
+
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -40,6 +42,16 @@ public class JwtTokenProvider {
 
     // 토큰 생성 메서드 (로그인 성공 시 호출됨)
     public String createToken(Authentication authentication) {
+
+        // Authentication 객체에서 Principal을 꺼냅니다.
+        Object principal = authentication.getPrincipal();
+
+        // Principal을 CustomUserDetails로 형변환
+        CustomUserDetails userDetails = (CustomUserDetails) principal;
+
+        // CustomUserDetails에 저장해둔 PK를 꺼냄
+        Long userId = userDetails.getUserId(); // PK(id)가져오기 성공
+
         // Authentication 객체에서 권한 정보 가져오기
         String authorities =
                 authentication.getAuthorities().stream()
@@ -52,6 +64,7 @@ public class JwtTokenProvider {
         return Jwts.builder()
                 .setSubject(authentication.getName()) // 로그인 할 아이디, email
                 .claim(AUTHORITIES_KEY, authorities) // 권한정보
+                .claim("userId", userId) // 가져온 PK를 클레임에 추가
                 .signWith(key, SignatureAlgorithm.HS512) // 비밀키로 서명
                 .setExpiration(validity) // 만료시간 설정
                 .compact();

--- a/src/main/java/com/example/projectlxp/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/projectlxp/global/jwt/JwtTokenProvider.java
@@ -1,0 +1,88 @@
+package com.example.projectlxp.global.jwt;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+
+@Component
+public class JwtTokenProvider {
+
+    private final SecretKey key;
+    private final long accessTokenExpirationMs;
+
+    private static final String AUTHORITIES_KEY = "auth";
+
+    // applcation-locla.yml 에서 설정 값 가져오기
+    public JwtTokenProvider(
+            @Value("${jwt.secret}") String secretKey,
+            @Value("${jwt.access-token-expiration-ms}") long accessTokenExpirationMs) {
+
+        // yml의 secret 문자열을 SecretKry 객체로 변환
+        this.key = Keys.hmacShaKeyFor(secretKey.getBytes());
+        this.accessTokenExpirationMs = accessTokenExpirationMs;
+    }
+
+    // 토큰 생성 메서드 (로그인 성공 시 호출됨)
+    public String createToken(Authentication authentication) {
+        // Authentication 객체에서 권한 정보 가져오기
+        String authorities =
+                authentication.getAuthorities().stream()
+                        .map(GrantedAuthority::getAuthority)
+                        .collect(Collectors.joining(","));
+
+        long now = (new Date()).getTime();
+        Date validity = new Date(now + this.accessTokenExpirationMs); // 만료시간
+
+        return Jwts.builder()
+                .setSubject(authentication.getName()) // 로그인 할 아이디, email
+                .claim(AUTHORITIES_KEY, authorities) // 권한정보
+                .signWith(key, SignatureAlgorithm.HS512) // 비밀키로 서명
+                .setExpiration(validity) // 만료시간 설정
+                .compact();
+    }
+
+    /*
+     * 토큰에서 인증 정보 추출
+     * */
+    public Authentication getAuthentication(String token) {
+        // 토큰을 복호화하여 claims을 꺼냄
+        Claims claims =
+                Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+
+        Collection<? extends GrantedAuthority> authorities =
+                Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(","))
+                        .map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toList());
+
+        User principal = new User(claims.getSubject(), "", authorities);
+
+        return new UsernamePasswordAuthenticationToken(principal, token, authorities);
+    }
+
+    // 토큰 검증 메서드
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/example/projectlxp/review/controller/ReviewController.java
+++ b/src/main/java/com/example/projectlxp/review/controller/ReviewController.java
@@ -23,7 +23,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/reviews")
+@RequestMapping("/reviews")
 public class ReviewController {
     private final ReviewService reviewService;
 

--- a/src/main/java/com/example/projectlxp/user/controller/UserController.java
+++ b/src/main/java/com/example/projectlxp/user/controller/UserController.java
@@ -4,25 +4,22 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.example.projectlxp.user.dto.TokenResponseDTO;
 import com.example.projectlxp.user.dto.UserJoinRequestDTO;
+import com.example.projectlxp.user.dto.UserLoginRequestDTO;
 import com.example.projectlxp.user.service.UserService;
 
 import lombok.RequiredArgsConstructor;
 
-// todo restController로
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api")
 public class UserController {
 
     private final UserService userService;
 
-    /*
-     * 회원가입 API
-     * */
+    // 회원가입 API
     @PostMapping("/join")
     public ResponseEntity<String> join(
             // @RequestBody : Form 데이터가 아님 JSON 데이터를 DTO로 변환
@@ -31,5 +28,13 @@ public class UserController {
 
         userService.join(requestDTO);
         return ResponseEntity.ok("회원가입 되셨습니다.");
+    }
+
+    // 로그인 API
+    @PostMapping("/login")
+    public ResponseEntity<TokenResponseDTO> lgoin(
+            @Validated @RequestBody UserLoginRequestDTO requestDTO) {
+        String jwtToken = userService.login(requestDTO);
+        return ResponseEntity.ok(new TokenResponseDTO(jwtToken));
     }
 }

--- a/src/main/java/com/example/projectlxp/user/controller/UserController.java
+++ b/src/main/java/com/example/projectlxp/user/controller/UserController.java
@@ -32,9 +32,10 @@ public class UserController {
 
     // 로그인 API
     @PostMapping("/login")
-    public ResponseEntity<TokenResponseDTO> lgoin(
+    public ResponseEntity<TokenResponseDTO> login(
             @Validated @RequestBody UserLoginRequestDTO requestDTO) {
-        String jwtToken = userService.login(requestDTO);
-        return ResponseEntity.ok(new TokenResponseDTO(jwtToken));
+
+        TokenResponseDTO tokenDTO = userService.login(requestDTO);
+        return ResponseEntity.ok(tokenDTO);
     }
 }

--- a/src/main/java/com/example/projectlxp/user/dto/CustomUserDetails.java
+++ b/src/main/java/com/example/projectlxp/user/dto/CustomUserDetails.java
@@ -1,0 +1,26 @@
+package com.example.projectlxp.user.dto;
+
+import java.util.Collection;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+public class CustomUserDetails extends User {
+
+    private final Long userId;
+
+    public CustomUserDetails(
+            Long userId,
+            String email,
+            String password,
+            Collection<? extends GrantedAuthority> authorities) {
+
+        // 부모클래스 생성자 호출
+        super(email, password, authorities);
+        this.userId = userId;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+}

--- a/src/main/java/com/example/projectlxp/user/dto/CustomUserDetails.java
+++ b/src/main/java/com/example/projectlxp/user/dto/CustomUserDetails.java
@@ -5,6 +5,9 @@ import java.util.Collection;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 
+import lombok.Getter;
+
+@Getter
 public class CustomUserDetails extends User {
 
     private final Long userId;
@@ -18,9 +21,5 @@ public class CustomUserDetails extends User {
         // 부모클래스 생성자 호출
         super(email, password, authorities);
         this.userId = userId;
-    }
-
-    public Long getUserId() {
-        return userId;
     }
 }

--- a/src/main/java/com/example/projectlxp/user/dto/TokenResponseDTO.java
+++ b/src/main/java/com/example/projectlxp/user/dto/TokenResponseDTO.java
@@ -6,9 +6,11 @@ import lombok.Getter;
 public class TokenResponseDTO {
 
     private String accesstoken;
+    private String refreshtoken;
     private String tokenType = "Bearer"; // 출입증
 
-    public TokenResponseDTO(String accesstoken) {
+    public TokenResponseDTO(String accesstoken, String refreshtoken) {
         this.accesstoken = accesstoken;
+        this.refreshtoken = refreshtoken;
     }
 }

--- a/src/main/java/com/example/projectlxp/user/dto/TokenResponseDTO.java
+++ b/src/main/java/com/example/projectlxp/user/dto/TokenResponseDTO.java
@@ -1,0 +1,14 @@
+package com.example.projectlxp.user.dto;
+
+import lombok.Getter;
+
+@Getter
+public class TokenResponseDTO {
+
+    private String accesstoken;
+    private String tokenType = "Bearer"; // 출입증
+
+    public TokenResponseDTO(String accesstoken) {
+        this.accesstoken = accesstoken;
+    }
+}

--- a/src/main/java/com/example/projectlxp/user/dto/UserLoginRequestDTO.java
+++ b/src/main/java/com/example/projectlxp/user/dto/UserLoginRequestDTO.java
@@ -1,0 +1,20 @@
+package com.example.projectlxp.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserLoginRequestDTO {
+
+    // config에서 동일한 필드명 선정
+    @NotBlank(message = "이메일을 입력해주세요.")
+    private String email;
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    private String password;
+}

--- a/src/main/java/com/example/projectlxp/user/dto/UserUpdateRequestDTO.java
+++ b/src/main/java/com/example/projectlxp/user/dto/UserUpdateRequestDTO.java
@@ -1,0 +1,18 @@
+package com.example.projectlxp.user.dto;
+
+import jakarta.validation.constraints.Size;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor // 테스트용
+public class UserUpdateRequestDTO {
+
+    @Size(max = 20, message = "이름은 20자를 초과할 수 없습니다.")
+    private String name;
+
+    private String profileImage;
+}

--- a/src/main/java/com/example/projectlxp/user/service/CustomUserDetailService.java
+++ b/src/main/java/com/example/projectlxp/user/service/CustomUserDetailService.java
@@ -1,0 +1,44 @@
+package com.example.projectlxp.user.service;
+
+import java.util.Collections;
+
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.projectlxp.user.dto.CustomUserDetails;
+import com.example.projectlxp.user.entity.User;
+import com.example.projectlxp.user.repository.UserRepository;
+
+@Service
+public class CustomUserDetailService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    // 생성자 이름 수정
+    public CustomUserDetailService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    @Transactional
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+
+        User user =
+                userRepository
+                        .findByEmail(email)
+                        .orElseThrow(
+                                () ->
+                                        new UsernameNotFoundException(
+                                                "User not found with username: " + email));
+
+        return new CustomUserDetails(
+                user.getId(),
+                user.getEmail(),
+                user.getHashedPassword(),
+                Collections.singletonList(new SimpleGrantedAuthority(user.getRole().name())));
+    }
+}

--- a/src/main/java/com/example/projectlxp/user/service/UserService.java
+++ b/src/main/java/com/example/projectlxp/user/service/UserService.java
@@ -1,6 +1,8 @@
 package com.example.projectlxp.user.service;
 
+import com.example.projectlxp.user.dto.TokenResponseDTO;
 import com.example.projectlxp.user.dto.UserJoinRequestDTO;
+import com.example.projectlxp.user.dto.UserLoginRequestDTO;
 
 public interface UserService {
 
@@ -10,4 +12,7 @@ public interface UserService {
      * */
 
     void join(UserJoinRequestDTO requestDTO);
+
+    // 로그인
+    TokenResponseDTO login(UserLoginRequestDTO requestDTO);
 }

--- a/src/main/java/com/example/projectlxp/user/service/UserService.java
+++ b/src/main/java/com/example/projectlxp/user/service/UserService.java
@@ -14,5 +14,10 @@ public interface UserService {
     void join(UserJoinRequestDTO requestDTO);
 
     // 로그인
+
     TokenResponseDTO login(UserLoginRequestDTO requestDTO);
+
+    // 정보 조회
+
+    // 정보수정
 }

--- a/src/main/java/com/example/projectlxp/user/service/UserServiceImpl.java
+++ b/src/main/java/com/example/projectlxp/user/service/UserServiceImpl.java
@@ -1,5 +1,9 @@
 package com.example.projectlxp.user.service;
 
+import org.springframework.context.annotation.Lazy;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -7,26 +11,38 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.example.projectlxp.global.jwt.JwtTokenProvider;
+import com.example.projectlxp.user.dto.TokenResponseDTO;
 import com.example.projectlxp.user.dto.UserJoinRequestDTO;
+import com.example.projectlxp.user.dto.UserLoginRequestDTO;
 import com.example.projectlxp.user.entity.User;
 import com.example.projectlxp.user.repository.UserRepository;
 
-import lombok.RequiredArgsConstructor;
-
 @Service
-@RequiredArgsConstructor
 public class UserServiceImpl implements UserService, UserDetailsService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
 
+    // 로그인
+    private final AuthenticationManager authenticationManager;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public UserServiceImpl(
+            UserRepository userRepository,
+            PasswordEncoder passwordEncoder,
+            @Lazy AuthenticationManager authenticationManager,
+            JwtTokenProvider jwtTokenProvider) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.authenticationManager = authenticationManager;
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
     // 회원가입
     @Override
     @Transactional // DB에 데이터를 저장
     public void join(UserJoinRequestDTO requestDTO) {
-
-        // -- 테스트 코드 ---
-
         // 이메일 중복 체크
         if (userRepository.findByEmail(requestDTO.getEmail()).isPresent()) {
             throw new IllegalStateException("이미 가입된 이메일입니다.");
@@ -35,13 +51,8 @@ public class UserServiceImpl implements UserService, UserDetailsService {
         userRepository.save(newUser);
     }
 
-    // 로그인
-    /*
-     * spring Security가 로그인을 처리할 때 호출하는 메서드
-     * @param username (로그인 시도하는 ID, 여기서는 email)
-     * @return UserDetails (Spring Security가 사용하는 User정보)
-     * @throws UsernameNotFoundException
-     * */
+    // 로그인 (loadUserByUsername)
+    // spring Security가 인증 시 호출
     @Override
     @Transactional(readOnly = true)
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
@@ -61,5 +72,24 @@ public class UserServiceImpl implements UserService, UserDetailsService {
                 .password(user.getHashedPassword()) // DB에 저장된 암호화된 PW
                 .roles(user.getRole().name()) // 권한
                 .build();
+    }
+
+    // 로그인 - Controller가 토큰 발급 시 호출
+    @Override
+    public TokenResponseDTO login(UserLoginRequestDTO requestDTO) {
+
+        // ID/PW로 인증 토큰 생성
+        UsernamePasswordAuthenticationToken authenticationToken =
+                new UsernamePasswordAuthenticationToken(
+                        requestDTO.getEmail(), requestDTO.getPassword());
+
+        // AuthenticationManager로 인증 (loadUserByUsername 호출 및 비번 비교
+        Authentication authentication = authenticationManager.authenticate(authenticationToken);
+
+        String accessToken = jwtTokenProvider.createAccessToken(authentication); // 액세스 토큰 발급
+        String refreshToken = jwtTokenProvider.createRefreshToken(authentication); // 리프레쉬 토큰 발급
+
+        // 인증 성공 시 , JWT 토큰 생성
+        return new TokenResponseDTO(accessToken, refreshToken);
     }
 }


### PR DESCRIPTION
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->

## ❗️ 이슈 번호
#28 

## 📝 작업 내용
- 로그인 및 로그아웃 API 구현 JWP 토큰 방식 
- Security  권한 설정 회원가입 , 로그인은 누구나 petmitAll()로 설정 
- 커스텀 클레임으로 user의 pk 설정 
- access , refresh 토큰 둘다 발급 
- login 후 정보는 header로 받을 수 있음 
 
## 💭 주의 사항
localhost:8080/join
localhost:8080/login 에서 토큰 값을 가져옵니다
localhost:8080/corses 에서 Bearer 토큰값을 넣어주면 됩니다. 

```json
{
    "eamil" : "",
    "passowrd": ""
}  
```

## 💡 리뷰 포인트
<img width="827" height="188" alt="image" src="https://github.com/user-attachments/assets/fe098e66-4758-4c80-b357-6a9845bf7870" />


<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->
