### PR TITLE
[FEAT] 리뷰 삭제 기능 구현 (Controller, Service)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 
     // Database
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     runtimeOnly 'com.mysql:mysql-connector-j'
 
@@ -45,8 +46,8 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     // Security
-     implementation 'org.springframework.boot:spring-boot-starter-security'
-     testImplementation 'org.springframework.security:spring-security-test'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
 
     // JMT
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/src/main/java/com/example/projectlxp/review/controller/ReviewController.java
+++ b/src/main/java/com/example/projectlxp/review/controller/ReviewController.java
@@ -3,6 +3,7 @@ package com.example.projectlxp.review.controller;
 import jakarta.validation.Valid;
 
 import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -47,5 +48,14 @@ public class ReviewController {
                 reviewService.createReview(courseId, requestDTO, tempUserId);
 
         return BaseResponse.success(responseDTO);
+    }
+
+    @DeleteMapping("/{reviewId}")
+    public BaseResponse<Void> deleteReview(
+            @PathVariable Long reviewId,
+            @RequestParam(defaultValue = "1") Long tempUserId // (임시) 임시 유저 ID를 받음
+            ) {
+        reviewService.deleteReview(reviewId, tempUserId);
+        return BaseResponse.success(null);
     }
 }

--- a/src/main/java/com/example/projectlxp/review/service/ReviewService.java
+++ b/src/main/java/com/example/projectlxp/review/service/ReviewService.java
@@ -25,4 +25,12 @@ public interface ReviewService {
      * @return 생성된 리뷰의 상세 DTO
      */
     ReviewResponseDTO createReview(Long courseId, ReviewRequestDTO requestDTO, Long userId);
+
+    /**
+     * [ #37 ] 리뷰 삭제
+     *
+     * @param reviewId 삭제할 리뷰의 ID
+     * @param userId (임시) 삭제를 요청한 유저의 ID
+     */
+    void deleteReview(Long reviewId, Long userId);
 }

--- a/src/main/java/com/example/projectlxp/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/example/projectlxp/review/service/ReviewServiceImpl.java
@@ -115,12 +115,16 @@ public class ReviewServiceImpl implements ReviewService {
                                         new IllegalArgumentException(
                                                 "해당 리뷰를 찾을 수 없습니다. id=" + reviewId));
 
-        Long reviewOwnerId = review.getUser().getId();
-
-        if (!reviewOwnerId.equals(userId)) {
-            throw new RuntimeException("리뷰를 삭제할 권한이 없습니다.");
-        }
+        this.checkReviewOwner(review, user);
 
         reviewRepository.delete(review);
+    }
+
+    private void checkReviewOwner(Review review, User user) {
+        Long reviewOwnerId = review.getUser().getId();
+        if (!reviewOwnerId.equals(user.getId())) {
+
+            throw new RuntimeException("해당 리뷰에 대한 권한이 없습니다.");
+        }
     }
 }

--- a/src/main/java/com/example/projectlxp/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/example/projectlxp/review/service/ReviewServiceImpl.java
@@ -94,4 +94,33 @@ public class ReviewServiceImpl implements ReviewService {
 
         return new ReviewResponseDTO(savedReview);
     }
+
+    @Transactional
+    @Override
+    public void deleteReview(Long reviewId, Long userId) {
+
+        User user =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(
+                                () ->
+                                        new IllegalArgumentException(
+                                                "해당 유저를 찾을 수 없습니다. id=" + userId));
+
+        Review review =
+                reviewRepository
+                        .findById(reviewId)
+                        .orElseThrow(
+                                () ->
+                                        new IllegalArgumentException(
+                                                "해당 리뷰를 찾을 수 없습니다. id=" + reviewId));
+
+        Long reviewOwnerId = review.getUser().getId();
+
+        if (!reviewOwnerId.equals(userId)) {
+            throw new RuntimeException("리뷰를 삭제할 권한이 없습니다.");
+        }
+
+        reviewRepository.delete(review);
+    }
 }

--- a/src/main/java/com/example/projectlxp/user/dto/UserJoinRequestDTO.java
+++ b/src/main/java/com/example/projectlxp/user/dto/UserJoinRequestDTO.java
@@ -36,12 +36,11 @@ public class UserJoinRequestDTO {
 
     // "STUDENT" 또는 "INSTRUCTOR" 문자열로 받습니다.
     @NotBlank(message = "역할은 필수 항목입니다.")
-
     @Pattern(
             regexp = "(?i)^(STUDENT|INSTRUCTOR)$",
-            message = "역할은 'STUDENT' 또는 'INSTRUCTOR'만 가능합니다."
-    )
+            message = "역할은 'STUDENT' 또는 'INSTRUCTOR'만 가능합니다.")
     private String role;
+
     private String profileImage;
 
     // -- Entity 변환 로직 (Service에서 사용) ---


### PR DESCRIPTION
## ❗️ 이슈 번호
#37 

## 📝 작업 내용
1. Controller (ReviewController)

DELETE /api/reviews/{reviewId} 엔드포인트를 추가.

@DeleteMapping 및 @PathVariable을 사용.



2. Service (ReviewServiceImpl, ReviewService)

deleteReview 메서드를 추가했습니다.

본인이 아닐 경우, "리뷰를 삭제할 권한이 없습니다." RuntimeException을 발생.


## 💭 주의 사항
(테스트 3: 성공) DELETE /api/reviews/1?tempUserId=2 (본인 리뷰) ➡️ 200 OK (data: null) 반환 확인.
global패키지에 config패키지에 SecurityConfig 클래스 파일에 securityFillterChain 메서드 수정 후 테스트 해봐야 해서 바꿔서 테스트 해서 200 확인 후 일단은 그대로 돌려놨습니다.

## 💡 리뷰 포인트
Service의 deleteReview가 올바르게 구현되었는지 확인 부탁드립니다.
