### PR TITLE
[FEAT] 섹션 삭제 API 구현

### DIFF
--- a/src/main/java/com/example/projectlxp/lecture/repository/LectureRepository.java
+++ b/src/main/java/com/example/projectlxp/lecture/repository/LectureRepository.java
@@ -1,9 +1,16 @@
 package com.example.projectlxp.lecture.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import com.example.projectlxp.lecture.entity.Lecture;
 
 @Repository
-public interface LectureRepository extends JpaRepository<Lecture, Long> {}
+public interface LectureRepository extends JpaRepository<Lecture, Long> {
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE Lecture l SET l.isDeleted = true WHERE l.section.id = :sectionId")
+    void deleteBySectionId(Long sectionId);
+}

--- a/src/main/java/com/example/projectlxp/section/controller/SectionController.java
+++ b/src/main/java/com/example/projectlxp/section/controller/SectionController.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -47,5 +48,11 @@ public class SectionController {
                 sectionService.modifySection(sectionId, request.title, request.orderNo);
 
         return BaseResponse.success(updatedSection);
+    }
+
+    @DeleteMapping("/{sectionId}")
+    public BaseResponse<Void> deleteSection(@PathVariable(name = "sectionId") Long sectionId) {
+        sectionService.removeSection(sectionId);
+        return BaseResponse.success("Deleted Section", null);
     }
 }

--- a/src/main/java/com/example/projectlxp/section/repository/SectionRepository.java
+++ b/src/main/java/com/example/projectlxp/section/repository/SectionRepository.java
@@ -3,6 +3,9 @@ package com.example.projectlxp.section.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.example.projectlxp.section.entity.Section;
@@ -11,4 +14,19 @@ import com.example.projectlxp.section.entity.Section;
 public interface SectionRepository extends JpaRepository<Section, Long> {
 
     Optional<Section> findByCourseIdAndOrderNo(Long courseId, int orderNo);
+
+    /**
+     * Section 삭제 후, 뒤에 오는 섹션들의 orderNo를 1씩 감소시킵니다.
+     *
+     * <p>예시) orderNo = 3인 섹션이 삭제되면, 기존 orderNo 4, 5, 6번 섹션들이 각각 3, 4, 5로 변경됩니다.
+     *
+     * @param courseId 해당 섹션이 속한 Course의 ID
+     * @param deletedOrderNo 삭제된 섹션의 orderNo
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(
+            "UPDATE Section s SET s.orderNo = s.orderNo - 1 "
+                    + "WHERE s.course.id = :courseId AND s.orderNo > :orderNo")
+    void decrementOrderAfterDelete(
+            @Param("courseId") Long courseId, @Param("orderNo") int deletedOrderNo);
 }

--- a/src/main/java/com/example/projectlxp/section/service/SectionService.java
+++ b/src/main/java/com/example/projectlxp/section/service/SectionService.java
@@ -24,4 +24,11 @@ public interface SectionService {
      * @return SectionUpdateResponseDTO
      */
     SectionUpdateResponseDTO modifySection(Long sectionId, String title, int orderNo);
+
+    /**
+     * 섹션을 삭제합니다. - 섹션이 삭제되면 관련 Lecture도 삭제됩니다. - 중간 섹션을 삭제하면 orderNo가 재정렬 됩니다.
+     *
+     * @param sectionId 섹션(Section)의 ID값
+     */
+    void removeSection(Long sectionId);
 }


### PR DESCRIPTION
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->

## ❗️ 이슈 번호
#36 

## 📝 작업 내용
**1. Section Repository**
- JPQL을 사용하여 삭제되는 Section의 orderNo의 하위의 orderNo값을 1씩 감소하는 `decrementOrderAfeterDelet` 메서드를 구현하였습니다.

**2. SectionServiceImpl**
- Section이 없는 경우 오류를 내뱉도록 구현하였습니다.
- section 삭제 -> lecture 삭제 -> orderNo 재정렬 순서로 작업하도록 로직을 구현하였습니다.
- `is_deleted`가 true가 되는 soft delete로 삭제되도록 구현하였습니다. 

## 💭 주의 사항
1. Repository
- `@Modifying`을 사용하여 JPQL 구문이 업데이트임을 알렸습니다.
- `@Modifying`의 매개변수를 사용하였습니다.
- `clearAutomatically = true` : 쿼리 실행 후 persist 1차 캐싱을 비운다. 변경된 내용을 즉시 반영하도록 한다.
- `flushAutomatically = true` : 쿼리 실행 전에 미쳐 반영되지 않은 변경 사항을 DB에 flush한다.

## 💡 리뷰 포인트
`@Modifying` 어노테이션을 사용하여 영속성 컨텍스트와 DB간의 불일치를 방지하였습니다.
다만, 여기서 영속성 1차 캐싱을 지우는 것이 맞는지 의문스럽습니다 !
의견 주시면 감사하겠습니다 !

`@Modifying`을 사용하지 않으면 단순한 Select 구문으로 인식하는 것을 배웠습니다 !
