### PR TITLE
[FEAT] 전역 예외 핸들러 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,6 @@ dependencies {
 
     // Database
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     runtimeOnly 'com.mysql:mysql-connector-j'
 
     // Lombok

--- a/src/main/java/com/example/projectlxp/enrollment/dto/request/CreateEnrollmentRequestDTO.java
+++ b/src/main/java/com/example/projectlxp/enrollment/dto/request/CreateEnrollmentRequestDTO.java
@@ -12,5 +12,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CreateEnrollmentRequestDTO {
-    @NotNull private Long courseId;
+    @NotNull(message = "강좌 ID는 필수 값입니다.")
+    private Long courseId;
 }

--- a/src/main/java/com/example/projectlxp/enrollment/service/EnrollmentServiceImpl.java
+++ b/src/main/java/com/example/projectlxp/enrollment/service/EnrollmentServiceImpl.java
@@ -2,6 +2,7 @@ package com.example.projectlxp.enrollment.service;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,6 +14,7 @@ import com.example.projectlxp.enrollment.dto.response.EnrolledCourseDTO;
 import com.example.projectlxp.enrollment.dto.response.PagedEnrolledCourseDTO;
 import com.example.projectlxp.enrollment.entity.Enrollment;
 import com.example.projectlxp.enrollment.repository.EnrollmentRepository;
+import com.example.projectlxp.global.error.CustomBusinessException;
 import com.example.projectlxp.user.entity.User;
 import com.example.projectlxp.user.repository.UserRepository;
 
@@ -41,19 +43,24 @@ public class EnrollmentServiceImpl implements EnrollmentService {
                 userRepository
                         .findById(userId)
                         .orElseThrow(
-                                () -> new IllegalArgumentException("존재하지 않는 회원입니다. ID: " + userId));
+                                () ->
+                                        new CustomBusinessException(
+                                                "존재하지 않는 회원입니다. ID: " + userId,
+                                                HttpStatus.NOT_FOUND));
 
         Course course =
                 courseRepository
                         .findById(requestDTO.getCourseId())
                         .orElseThrow(
                                 () ->
-                                        new IllegalArgumentException(
-                                                "존재하지 않는 강좌입니다. ID: " + requestDTO.getCourseId()));
+                                        new CustomBusinessException(
+                                                "존재하지 않는 강좌입니다. ID: " + requestDTO.getCourseId(),
+                                                HttpStatus.NOT_FOUND));
 
         if (enrollmentRepository.existsByUserAndCourse(user, course)) {
-            throw new IllegalStateException(
-                    "이미 등록된 강좌입니다. 회원 ID: " + userId + ", 강좌 ID: " + requestDTO.getCourseId());
+            throw new CustomBusinessException(
+                    "이미 등록된 강좌입니다. 회원 ID: " + userId + ", 강좌 ID: " + requestDTO.getCourseId(),
+                    HttpStatus.CONFLICT);
         }
 
         Enrollment enrollment = Enrollment.builder().user(user).course(course).build();
@@ -68,7 +75,7 @@ public class EnrollmentServiceImpl implements EnrollmentService {
                 userRepository
                         .findById(userId)
                         .orElseThrow(
-                                () -> new IllegalArgumentException("존재하지 않는 회원입니다. ID: " + userId));
+                                () -> new CustomBusinessException("존재하지 않는 회원입니다. ID: " + userId));
 
         Page<Enrollment> enrollmentPage =
                 enrollmentRepository.findByUserIdWithCourse(user.getId(), pageable);

--- a/src/main/java/com/example/projectlxp/global/dto/BaseResponse.java
+++ b/src/main/java/com/example/projectlxp/global/dto/BaseResponse.java
@@ -15,14 +15,14 @@ public class BaseResponse<T> extends ResponseDTO {
     }
 
     public static <T> BaseResponse<T> success(T data) {
-        return new BaseResponse<T>(HttpStatus.OK, HttpStatus.OK.name(), data);
+        return new BaseResponse<>(HttpStatus.OK, HttpStatus.OK.name(), data);
     }
 
     public static <T> BaseResponse<T> success(String message, T data) {
-        return new BaseResponse<T>(HttpStatus.OK, message, data);
+        return new BaseResponse<>(HttpStatus.OK, message, data);
     }
 
     public static <T> BaseResponse<T> error(HttpStatus status, String message) {
-        return new BaseResponse<T>(status, message, null);
+        return new BaseResponse<>(status, message, null);
     }
 }

--- a/src/main/java/com/example/projectlxp/global/error/ApiControllerAdvice.java
+++ b/src/main/java/com/example/projectlxp/global/error/ApiControllerAdvice.java
@@ -1,0 +1,42 @@
+package com.example.projectlxp.global.error;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.example.projectlxp.global.dto.BaseResponse;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class ApiControllerAdvice {
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(BindException.class)
+    public BaseResponse<Object> bindException(BindException e) {
+        return BaseResponse.error(
+                HttpStatus.BAD_REQUEST,
+                e.getBindingResult().getAllErrors().get(0).getDefaultMessage());
+    }
+
+    @ExceptionHandler(CustomBusinessException.class)
+    public BaseResponse<Object> handleCustomBusinessException(CustomBusinessException e) {
+        return BaseResponse.error(e.getHttpStatus(), e.getMessage());
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(IllegalArgumentException.class)
+    public BaseResponse<Object> illegalArgumentException(IllegalArgumentException e) {
+        return BaseResponse.error(HttpStatus.BAD_REQUEST, e.getMessage());
+    }
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(Exception.class)
+    public BaseResponse<Object> handleException(Exception e) {
+        log.error("처리되지 않은 예외가 발생했습니다.", e);
+        return BaseResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.");
+    }
+}

--- a/src/main/java/com/example/projectlxp/global/error/CustomBusinessException.java
+++ b/src/main/java/com/example/projectlxp/global/error/CustomBusinessException.java
@@ -1,0 +1,32 @@
+package com.example.projectlxp.global.error;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+
+@Getter
+public class CustomBusinessException extends RuntimeException {
+
+    private final HttpStatus httpStatus;
+
+    /**
+     * 예외 메시지만으로 생성합니다.
+     *
+     * @param message 예외 핸들러가 반환할 메시지
+     */
+    public CustomBusinessException(String message) {
+        // 기본 상태 코드를 400 Bad Request로 설정합니다.
+        this(message, HttpStatus.BAD_REQUEST);
+    }
+
+    /**
+     * 예외 메시지와 HTTP 상태 코드를 함께 생성합니다.
+     *
+     * @param message 예외 핸들러가 반환할 메시지
+     * @param httpStatus 예외 핸들러가 반환할 HTTP 상태
+     */
+    public CustomBusinessException(String message, HttpStatus httpStatus) {
+        super(message);
+        this.httpStatus = httpStatus;
+    }
+}

--- a/src/test/java/com/example/projectlxp/enrollment/controller/EnrollmentControllerTest.java
+++ b/src/test/java/com/example/projectlxp/enrollment/controller/EnrollmentControllerTest.java
@@ -2,6 +2,7 @@ package com.example.projectlxp.enrollment.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -17,6 +18,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -27,6 +29,7 @@ import com.example.projectlxp.enrollment.dto.response.PagedEnrolledCourseDTO;
 import com.example.projectlxp.enrollment.service.EnrollmentService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+@WithMockUser
 @WebMvcTest(EnrollmentController.class)
 class EnrollmentControllerTest {
     @Autowired private MockMvc mockMvc;
@@ -60,7 +63,9 @@ class EnrollmentControllerTest {
 
         /// when // then
         mockMvc.perform(
-                        post("/enrollments?userId=" + userId)
+                        post("/enrollments")
+                                .with(csrf())
+                                .param("userId", String.valueOf(userId))
                                 .content(objectMapper.writeValueAsString(request))
                                 .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
@@ -75,13 +80,15 @@ class EnrollmentControllerTest {
     void createOrderWithEmptyProductNumbers() throws Exception {
         // given
         CreateEnrollmentRequestDTO request = CreateEnrollmentRequestDTO.builder().build();
-
         // when // then
         mockMvc.perform(
-                        post("/enrollments?userId=1")
+                        post("/enrollments")
+                                .param("userId", "1")
                                 .content(objectMapper.writeValueAsString(request))
-                                .contentType(MediaType.APPLICATION_JSON))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .with(csrf()))
                 .andDo(print())
+                .andExpect(jsonPath("$.message").value("강좌 ID는 필수 값입니다."))
                 .andExpect(status().isBadRequest());
     }
 

--- a/src/test/java/com/example/projectlxp/enrollment/service/EnrollmentServiceImplTest.java
+++ b/src/test/java/com/example/projectlxp/enrollment/service/EnrollmentServiceImplTest.java
@@ -76,7 +76,7 @@ class EnrollmentServiceImplTest {
 
         // when - then
         assertThatThrownBy(() -> enrollmentService.enrollCourse(user2.getId(), requestDTO))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(RuntimeException.class)
                 .hasMessage("이미 등록된 강좌입니다. 회원 ID: " + user2.getId() + ", 강좌 ID: " + course.getId());
     }
 


### PR DESCRIPTION
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->

## ❗️ 이슈 번호
#40 

## 📝 작업 내용
본 예외 처리 시스템의 목적은 컨트롤러(Controller) 계층의 try-catch 구문 및 ResponseEntity 직접 생성을 배제하여 코드의 일관성을 확보하고, 예외 처리 책임을 ApiControllerAdvice로 중앙 집중화하는 데 있습니다.

**권장 방식 (TO-BE)**
```
@PostMapping("/course")
public BaseResponse<Object> createCourse(String title) {
    // 서비스 계층은 예외를 throw하고, 컨트롤러는 성공 로직만 담당한다.
    courseService.create(title);
    return BaseResponse.success("강좌 생성 성공");
}
```
서비스 계층에서 발생한 예외는 ApiControllerAdvice가 자동으로 감지하여 BaseResponse.error(...) 형식으로 변환 후 

**예외 사용 명세 (Exception Usage Specification)**

- **비즈니스 로직 예외 (CustomBusinessException)**
  - "존재하지 않는 회원입니다.", 
  - "이미 수강 중인 강좌입니다."

- **상황**: 서비스(Service) 계층의 로직 수행 중, 프로젝트의 비즈니스 규칙(정책) 상 오류가 발생할 때 사용합니다.
- **사용법**: 서비스 계층에서 CustomBusinessException을 throw 합니다. CustomBusinessException의 기본 HTTP 상태는 **400 (Bad Request)** 입니다. 404 (Not Found) 또는 409 (Conflict) 등 특정 상태 코드를 반환해야 할 경우, 생성자에 HttpStatus를 명시합니다.

```
// 1. 404 Not Found (존재하지 않음)
User user = userRepository.findById(userId)
        .orElseThrow(() -> new CustomBusinessException(
                "존재하지 않는 회원입니다.", HttpStatus.NOT_FOUND
        ));

// 2. 409 Conflict (데이터 충돌)
if (enrollmentRepository.existsByUserAndCourse(user, course)) {
    throw new CustomBusinessException(
            "이미 등록된 강좌입니다.", HttpStatus.CONFLICT
    );
}
```

## 💭 주의 사항

## 💡 리뷰 포인트
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->
