### PR TITLE
[FEAT] 단일 강좌 조회 API 기능 구현

### DIFF
--- a/src/main/java/com/example/projectlxp/category/error/CategoryNotFoundException.java
+++ b/src/main/java/com/example/projectlxp/category/error/CategoryNotFoundException.java
@@ -1,0 +1,12 @@
+package com.example.projectlxp.category.error;
+
+import org.springframework.http.HttpStatus;
+
+import com.example.projectlxp.global.error.CustomBusinessException;
+
+public class CategoryNotFoundException extends CustomBusinessException {
+
+    public CategoryNotFoundException() {
+        super("존재하지 않는 카테고리 ID입니다.", HttpStatus.NOT_FOUND);
+    }
+}

--- a/src/main/java/com/example/projectlxp/course/controller/CourseController.java
+++ b/src/main/java/com/example/projectlxp/course/controller/CourseController.java
@@ -1,5 +1,7 @@
 package com.example.projectlxp.course.controller;
 
+import jakarta.validation.Valid;
+
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -30,7 +32,7 @@ public class CourseController {
 
     @PostMapping
     public BaseResponse<CourseResponse> registerCourse(
-            @RequestBody CourseSaveRequest request, @RequestParam Long userId) {
+            @RequestBody @Valid CourseSaveRequest request, @RequestParam Long userId) {
         return BaseResponse.success(courseService.saveCourse(request, userId));
     }
 }

--- a/src/main/java/com/example/projectlxp/course/controller/CourseController.java
+++ b/src/main/java/com/example/projectlxp/course/controller/CourseController.java
@@ -1,5 +1,7 @@
 package com.example.projectlxp.course.controller;
 
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,6 +21,11 @@ public class CourseController {
 
     public CourseController(CourseService courseService) {
         this.courseService = courseService;
+    }
+
+    @GetMapping("/{courseId}")
+    public BaseResponse<CourseResponse> search(@PathVariable Long courseId) {
+        return BaseResponse.success(courseService.searchCourse(courseId));
     }
 
     @PostMapping

--- a/src/main/java/com/example/projectlxp/course/entity/CourseLevel.java
+++ b/src/main/java/com/example/projectlxp/course/entity/CourseLevel.java
@@ -3,6 +3,7 @@ package com.example.projectlxp.course.entity;
 import java.util.Arrays;
 import java.util.Objects;
 
+import com.example.projectlxp.course.error.InvalidCourseLevelException;
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 public enum CourseLevel {
@@ -13,13 +14,12 @@ public enum CourseLevel {
     @JsonCreator
     public static CourseLevel from(String value) {
         if (Objects.isNull(value) || value.isBlank()) {
-            throw new IllegalArgumentException("CourseLevel value cannot be null or blank");
+            throw new InvalidCourseLevelException("Course Level 값이 비어있습니다.");
         }
 
         return Arrays.stream(CourseLevel.values())
                 .filter(e -> e.name().equalsIgnoreCase(value))
                 .findFirst()
-                .orElseThrow(
-                        () -> new IllegalArgumentException("Invalid CourseLevel value: " + value));
+                .orElseThrow(InvalidCourseLevelException::new);
     }
 }

--- a/src/main/java/com/example/projectlxp/course/error/CourseCreationDeniedException.java
+++ b/src/main/java/com/example/projectlxp/course/error/CourseCreationDeniedException.java
@@ -1,0 +1,12 @@
+package com.example.projectlxp.course.error;
+
+import org.springframework.http.HttpStatus;
+
+import com.example.projectlxp.global.error.CustomBusinessException;
+
+public class CourseCreationDeniedException extends CustomBusinessException {
+
+    public CourseCreationDeniedException() {
+        super("강좌를 생성할 권한이 없습니다.", HttpStatus.FORBIDDEN);
+    }
+}

--- a/src/main/java/com/example/projectlxp/course/error/CourseNotFoundException.java
+++ b/src/main/java/com/example/projectlxp/course/error/CourseNotFoundException.java
@@ -1,0 +1,12 @@
+package com.example.projectlxp.course.error;
+
+import org.springframework.http.HttpStatus;
+
+import com.example.projectlxp.global.error.CustomBusinessException;
+
+public class CourseNotFoundException extends CustomBusinessException {
+
+    public CourseNotFoundException() {
+        super("요청하신 강좌를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+    }
+}

--- a/src/main/java/com/example/projectlxp/course/error/CourseNotSavedException.java
+++ b/src/main/java/com/example/projectlxp/course/error/CourseNotSavedException.java
@@ -1,0 +1,10 @@
+package com.example.projectlxp.course.error;
+
+import com.example.projectlxp.global.error.CustomBusinessException;
+
+public class CourseNotSavedException extends CustomBusinessException {
+
+    public CourseNotSavedException() {
+        super("강좌 저장에 실패했습니다.");
+    }
+}

--- a/src/main/java/com/example/projectlxp/course/error/InvalidCourseLevelException.java
+++ b/src/main/java/com/example/projectlxp/course/error/InvalidCourseLevelException.java
@@ -1,0 +1,14 @@
+package com.example.projectlxp.course.error;
+
+import com.example.projectlxp.global.error.CustomBusinessException;
+
+public class InvalidCourseLevelException extends CustomBusinessException {
+
+    public InvalidCourseLevelException() {
+        super("유효하지 않은 Course Level 입니다.");
+    }
+
+    public InvalidCourseLevelException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/projectlxp/course/repository/CourseRepository.java
+++ b/src/main/java/com/example/projectlxp/course/repository/CourseRepository.java
@@ -2,7 +2,6 @@ package com.example.projectlxp.course.repository;
 
 import java.util.Optional;
 
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -21,6 +20,11 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
     Optional<Course> findByIdAndCategoryIdAndInstructorId(
             Long courseId, Long categoryId, Long userId);
 
-    @EntityGraph(attributePaths = {"instructor"})
-    Optional<Course> findByIdAndInstructorId(Long courseId, Long userId);
+    @Query(
+            "SELECT c FROM Course c "
+                    + "JOIN FETCH c.instructor i "
+                    + "JOIN FETCH c.category cat "
+                    + "LEFT JOIN FETCH cat.parent p "
+                    + "WHERE c.id = :courseId")
+    Optional<Course> findByIdWithInstructorAndCategory(Long courseId);
 }

--- a/src/main/java/com/example/projectlxp/course/service/CourseService.java
+++ b/src/main/java/com/example/projectlxp/course/service/CourseService.java
@@ -6,4 +6,6 @@ import com.example.projectlxp.course.dto.CourseSaveRequest;
 public interface CourseService {
 
     CourseResponse saveCourse(CourseSaveRequest courseDTO, Long userId);
+
+    CourseResponse searchCourse(Long courseId);
 }

--- a/src/main/java/com/example/projectlxp/course/service/CourseServiceImpl.java
+++ b/src/main/java/com/example/projectlxp/course/service/CourseServiceImpl.java
@@ -17,6 +17,7 @@ import com.example.projectlxp.user.entity.User;
 import lombok.RequiredArgsConstructor;
 
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class CourseServiceImpl implements CourseService {
 
@@ -39,6 +40,16 @@ public class CourseServiceImpl implements CourseService {
                         .findByIdAndCategoryIdAndInstructorId(
                                 save.getId(), request.categoryId(), userId)
                         .orElseThrow(() -> new IllegalArgumentException("강좌 저장에 실패했습니다."));
+        return new CourseResponse(CourseDTO.from(course), null);
+    }
+
+    @Override
+    public CourseResponse searchCourse(Long courseId) {
+        Course course =
+                courseRepository
+                        .findByIdWithInstructorAndCategory(courseId)
+                        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 강좌 ID입니다."));
+
         return new CourseResponse(CourseDTO.from(course), null);
     }
 }

--- a/src/main/java/com/example/projectlxp/course/service/CourseServiceImpl.java
+++ b/src/main/java/com/example/projectlxp/course/service/CourseServiceImpl.java
@@ -10,6 +10,8 @@ import com.example.projectlxp.course.dto.CourseDTO;
 import com.example.projectlxp.course.dto.CourseResponse;
 import com.example.projectlxp.course.dto.CourseSaveRequest;
 import com.example.projectlxp.course.entity.Course;
+import com.example.projectlxp.course.error.CourseNotFoundException;
+import com.example.projectlxp.course.error.CourseNotSavedException;
 import com.example.projectlxp.course.repository.CourseRepository;
 import com.example.projectlxp.course.service.validator.CourseValidator;
 import com.example.projectlxp.user.entity.User;
@@ -39,7 +41,7 @@ public class CourseServiceImpl implements CourseService {
                 courseRepository
                         .findByIdAndCategoryIdAndInstructorId(
                                 save.getId(), request.categoryId(), userId)
-                        .orElseThrow(() -> new IllegalArgumentException("강좌 저장에 실패했습니다."));
+                        .orElseThrow(CourseNotSavedException::new);
         return new CourseResponse(CourseDTO.from(course), null);
     }
 
@@ -48,7 +50,7 @@ public class CourseServiceImpl implements CourseService {
         Course course =
                 courseRepository
                         .findByIdWithInstructorAndCategory(courseId)
-                        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 강좌 ID입니다."));
+                        .orElseThrow(CourseNotFoundException::new);
 
         return new CourseResponse(CourseDTO.from(course), null);
     }

--- a/src/main/java/com/example/projectlxp/course/service/validator/CourseValidator.java
+++ b/src/main/java/com/example/projectlxp/course/service/validator/CourseValidator.java
@@ -2,8 +2,11 @@ package com.example.projectlxp.course.service.validator;
 
 import org.springframework.stereotype.Component;
 
+import com.example.projectlxp.category.error.CategoryNotFoundException;
 import com.example.projectlxp.category.repository.CategoryRepository;
+import com.example.projectlxp.course.error.CourseCreationDeniedException;
 import com.example.projectlxp.course.repository.CourseRepository;
+import com.example.projectlxp.global.error.CustomBusinessException;
 import com.example.projectlxp.user.entity.Role;
 import com.example.projectlxp.user.entity.User;
 import com.example.projectlxp.user.repository.UserRepository;
@@ -28,13 +31,13 @@ public class CourseValidator {
         User user =
                 userRepository
                         .findById(userId)
-                        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 강사(User) ID입니다."));
+                        .orElseThrow(() -> new CustomBusinessException("존재하지 않는 강사(User) ID입니다."));
         if (user.getRole() != Role.INSTRUCTOR) {
-            throw new IllegalArgumentException("강좌를 생성할 권한이 없습니다.");
+            throw new CourseCreationDeniedException();
         }
 
         if (!categoryRepository.existsById(categoryId)) {
-            throw new IllegalArgumentException("존재하지 않는 카테고리 ID입니다.");
+            throw new CategoryNotFoundException();
         }
     }
 }

--- a/src/main/java/com/example/projectlxp/course/service/validator/CourseValidator.java
+++ b/src/main/java/com/example/projectlxp/course/service/validator/CourseValidator.java
@@ -4,6 +4,8 @@ import org.springframework.stereotype.Component;
 
 import com.example.projectlxp.category.repository.CategoryRepository;
 import com.example.projectlxp.course.repository.CourseRepository;
+import com.example.projectlxp.user.entity.Role;
+import com.example.projectlxp.user.entity.User;
 import com.example.projectlxp.user.repository.UserRepository;
 
 @Component
@@ -22,15 +24,13 @@ public class CourseValidator {
         this.categoryRepository = categoryRepository;
     }
 
-    public void validateCourseOwnership(Long courseId, Long userId) {
-        courseRepository
-                .findByIdAndInstructorId(courseId, userId)
-                .orElseThrow(() -> new IllegalArgumentException("사용자가 소유한 강좌가 아닙니다."));
-    }
-
     public void validateCourseCreation(Long categoryId, Long userId) {
-        if (!userRepository.existsById(userId)) {
-            throw new IllegalArgumentException("존재하지 않는 강사(User) ID입니다.");
+        User user =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 강사(User) ID입니다."));
+        if (user.getRole() != Role.INSTRUCTOR) {
+            throw new IllegalArgumentException("강좌를 생성할 권한이 없습니다.");
         }
 
         if (!categoryRepository.existsById(categoryId)) {

--- a/src/test/java/com/example/projectlxp/course/service/CourseServiceImplTest.java
+++ b/src/test/java/com/example/projectlxp/course/service/CourseServiceImplTest.java
@@ -67,4 +67,30 @@ class CourseServiceImplTest {
                 () -> assertEquals(1000, courseDTO.price()),
                 () -> assertNull(courseDTO.thumbnail()));
     }
+
+    @Test
+    void 단일_강좌를_조회한다() {
+        // given
+        User instructor = User.builder().name("testName").email("test@test.com").build();
+        Category category = Category.builder().name("testName").build();
+
+        Course course =
+                Course.builder()
+                        .title("testTitle")
+                        .description("testDescription")
+                        .level(CourseLevel.BEGINNER)
+                        .category(category)
+                        .instructor(instructor)
+                        .build();
+
+        // when
+        when(courseRepository.findByIdWithInstructorAndCategory(1L))
+                .thenReturn(Optional.of(course));
+        CourseDTO dto = courseService.searchCourse(1L).course();
+
+        // then
+        assertAll(
+                () -> assertEquals("testTitle", dto.title()),
+                () -> assertEquals("testDescription", dto.description()));
+    }
 }


### PR DESCRIPTION

## ❗️ 이슈 번호
Closes #42 

## 📝 작업 내용

- 강좌 정보 조회 기능 구현

## 💭 주의 사항

- 이후 section과 lecture 조회 기능 추가 예정입니다.

## 💡 리뷰 포인트
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->
