### PR TITLE
[FEAT] 리뷰 수정 기능 구현

### DIFF
--- a/src/main/java/com/example/projectlxp/category/error/CategoryNotFoundException.java
+++ b/src/main/java/com/example/projectlxp/category/error/CategoryNotFoundException.java
@@ -1,0 +1,12 @@
+package com.example.projectlxp.category.error;
+
+import org.springframework.http.HttpStatus;
+
+import com.example.projectlxp.global.error.CustomBusinessException;
+
+public class CategoryNotFoundException extends CustomBusinessException {
+
+    public CategoryNotFoundException() {
+        super("존재하지 않는 카테고리 ID입니다.", HttpStatus.NOT_FOUND);
+    }
+}

--- a/src/main/java/com/example/projectlxp/course/controller/CourseController.java
+++ b/src/main/java/com/example/projectlxp/course/controller/CourseController.java
@@ -1,5 +1,7 @@
 package com.example.projectlxp.course.controller;
 
+import jakarta.validation.Valid;
+
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -30,7 +32,7 @@ public class CourseController {
 
     @PostMapping
     public BaseResponse<CourseResponse> registerCourse(
-            @RequestBody CourseSaveRequest request, @RequestParam Long userId) {
+            @RequestBody @Valid CourseSaveRequest request, @RequestParam Long userId) {
         return BaseResponse.success(courseService.saveCourse(request, userId));
     }
 }

--- a/src/main/java/com/example/projectlxp/course/controller/CourseController.java
+++ b/src/main/java/com/example/projectlxp/course/controller/CourseController.java
@@ -1,5 +1,7 @@
 package com.example.projectlxp.course.controller;
 
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,6 +21,11 @@ public class CourseController {
 
     public CourseController(CourseService courseService) {
         this.courseService = courseService;
+    }
+
+    @GetMapping("/{courseId}")
+    public BaseResponse<CourseResponse> search(@PathVariable Long courseId) {
+        return BaseResponse.success(courseService.searchCourse(courseId));
     }
 
     @PostMapping

--- a/src/main/java/com/example/projectlxp/course/entity/CourseLevel.java
+++ b/src/main/java/com/example/projectlxp/course/entity/CourseLevel.java
@@ -3,6 +3,7 @@ package com.example.projectlxp.course.entity;
 import java.util.Arrays;
 import java.util.Objects;
 
+import com.example.projectlxp.course.error.InvalidCourseLevelException;
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 public enum CourseLevel {
@@ -13,13 +14,12 @@ public enum CourseLevel {
     @JsonCreator
     public static CourseLevel from(String value) {
         if (Objects.isNull(value) || value.isBlank()) {
-            throw new IllegalArgumentException("CourseLevel value cannot be null or blank");
+            throw new InvalidCourseLevelException("Course Level 값이 비어있습니다.");
         }
 
         return Arrays.stream(CourseLevel.values())
                 .filter(e -> e.name().equalsIgnoreCase(value))
                 .findFirst()
-                .orElseThrow(
-                        () -> new IllegalArgumentException("Invalid CourseLevel value: " + value));
+                .orElseThrow(InvalidCourseLevelException::new);
     }
 }

--- a/src/main/java/com/example/projectlxp/course/error/CourseCreationDeniedException.java
+++ b/src/main/java/com/example/projectlxp/course/error/CourseCreationDeniedException.java
@@ -1,0 +1,12 @@
+package com.example.projectlxp.course.error;
+
+import org.springframework.http.HttpStatus;
+
+import com.example.projectlxp.global.error.CustomBusinessException;
+
+public class CourseCreationDeniedException extends CustomBusinessException {
+
+    public CourseCreationDeniedException() {
+        super("강좌를 생성할 권한이 없습니다.", HttpStatus.FORBIDDEN);
+    }
+}

--- a/src/main/java/com/example/projectlxp/course/error/CourseNotFoundException.java
+++ b/src/main/java/com/example/projectlxp/course/error/CourseNotFoundException.java
@@ -1,0 +1,12 @@
+package com.example.projectlxp.course.error;
+
+import org.springframework.http.HttpStatus;
+
+import com.example.projectlxp.global.error.CustomBusinessException;
+
+public class CourseNotFoundException extends CustomBusinessException {
+
+    public CourseNotFoundException() {
+        super("요청하신 강좌를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+    }
+}

--- a/src/main/java/com/example/projectlxp/course/error/CourseNotSavedException.java
+++ b/src/main/java/com/example/projectlxp/course/error/CourseNotSavedException.java
@@ -1,0 +1,10 @@
+package com.example.projectlxp.course.error;
+
+import com.example.projectlxp.global.error.CustomBusinessException;
+
+public class CourseNotSavedException extends CustomBusinessException {
+
+    public CourseNotSavedException() {
+        super("강좌 저장에 실패했습니다.");
+    }
+}

--- a/src/main/java/com/example/projectlxp/course/error/InvalidCourseLevelException.java
+++ b/src/main/java/com/example/projectlxp/course/error/InvalidCourseLevelException.java
@@ -1,0 +1,14 @@
+package com.example.projectlxp.course.error;
+
+import com.example.projectlxp.global.error.CustomBusinessException;
+
+public class InvalidCourseLevelException extends CustomBusinessException {
+
+    public InvalidCourseLevelException() {
+        super("유효하지 않은 Course Level 입니다.");
+    }
+
+    public InvalidCourseLevelException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/projectlxp/course/repository/CourseRepository.java
+++ b/src/main/java/com/example/projectlxp/course/repository/CourseRepository.java
@@ -2,7 +2,6 @@ package com.example.projectlxp.course.repository;
 
 import java.util.Optional;
 
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -21,6 +20,11 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
     Optional<Course> findByIdAndCategoryIdAndInstructorId(
             Long courseId, Long categoryId, Long userId);
 
-    @EntityGraph(attributePaths = {"instructor"})
-    Optional<Course> findByIdAndInstructorId(Long courseId, Long userId);
+    @Query(
+            "SELECT c FROM Course c "
+                    + "JOIN FETCH c.instructor i "
+                    + "JOIN FETCH c.category cat "
+                    + "LEFT JOIN FETCH cat.parent p "
+                    + "WHERE c.id = :courseId")
+    Optional<Course> findByIdWithInstructorAndCategory(Long courseId);
 }

--- a/src/main/java/com/example/projectlxp/course/service/CourseService.java
+++ b/src/main/java/com/example/projectlxp/course/service/CourseService.java
@@ -6,4 +6,6 @@ import com.example.projectlxp.course.dto.CourseSaveRequest;
 public interface CourseService {
 
     CourseResponse saveCourse(CourseSaveRequest courseDTO, Long userId);
+
+    CourseResponse searchCourse(Long courseId);
 }

--- a/src/main/java/com/example/projectlxp/course/service/CourseServiceImpl.java
+++ b/src/main/java/com/example/projectlxp/course/service/CourseServiceImpl.java
@@ -17,6 +17,7 @@ import com.example.projectlxp.user.entity.User;
 import lombok.RequiredArgsConstructor;
 
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class CourseServiceImpl implements CourseService {
 
@@ -39,6 +40,16 @@ public class CourseServiceImpl implements CourseService {
                         .findByIdAndCategoryIdAndInstructorId(
                                 save.getId(), request.categoryId(), userId)
                         .orElseThrow(() -> new IllegalArgumentException("강좌 저장에 실패했습니다."));
+        return new CourseResponse(CourseDTO.from(course), null);
+    }
+
+    @Override
+    public CourseResponse searchCourse(Long courseId) {
+        Course course =
+                courseRepository
+                        .findByIdWithInstructorAndCategory(courseId)
+                        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 강좌 ID입니다."));
+
         return new CourseResponse(CourseDTO.from(course), null);
     }
 }

--- a/src/main/java/com/example/projectlxp/course/service/CourseServiceImpl.java
+++ b/src/main/java/com/example/projectlxp/course/service/CourseServiceImpl.java
@@ -10,6 +10,8 @@ import com.example.projectlxp.course.dto.CourseDTO;
 import com.example.projectlxp.course.dto.CourseResponse;
 import com.example.projectlxp.course.dto.CourseSaveRequest;
 import com.example.projectlxp.course.entity.Course;
+import com.example.projectlxp.course.error.CourseNotFoundException;
+import com.example.projectlxp.course.error.CourseNotSavedException;
 import com.example.projectlxp.course.repository.CourseRepository;
 import com.example.projectlxp.course.service.validator.CourseValidator;
 import com.example.projectlxp.user.entity.User;
@@ -39,7 +41,7 @@ public class CourseServiceImpl implements CourseService {
                 courseRepository
                         .findByIdAndCategoryIdAndInstructorId(
                                 save.getId(), request.categoryId(), userId)
-                        .orElseThrow(() -> new IllegalArgumentException("강좌 저장에 실패했습니다."));
+                        .orElseThrow(CourseNotSavedException::new);
         return new CourseResponse(CourseDTO.from(course), null);
     }
 
@@ -48,7 +50,7 @@ public class CourseServiceImpl implements CourseService {
         Course course =
                 courseRepository
                         .findByIdWithInstructorAndCategory(courseId)
-                        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 강좌 ID입니다."));
+                        .orElseThrow(CourseNotFoundException::new);
 
         return new CourseResponse(CourseDTO.from(course), null);
     }

--- a/src/main/java/com/example/projectlxp/course/service/validator/CourseValidator.java
+++ b/src/main/java/com/example/projectlxp/course/service/validator/CourseValidator.java
@@ -2,8 +2,11 @@ package com.example.projectlxp.course.service.validator;
 
 import org.springframework.stereotype.Component;
 
+import com.example.projectlxp.category.error.CategoryNotFoundException;
 import com.example.projectlxp.category.repository.CategoryRepository;
+import com.example.projectlxp.course.error.CourseCreationDeniedException;
 import com.example.projectlxp.course.repository.CourseRepository;
+import com.example.projectlxp.global.error.CustomBusinessException;
 import com.example.projectlxp.user.entity.Role;
 import com.example.projectlxp.user.entity.User;
 import com.example.projectlxp.user.repository.UserRepository;
@@ -28,13 +31,13 @@ public class CourseValidator {
         User user =
                 userRepository
                         .findById(userId)
-                        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 강사(User) ID입니다."));
+                        .orElseThrow(() -> new CustomBusinessException("존재하지 않는 강사(User) ID입니다."));
         if (user.getRole() != Role.INSTRUCTOR) {
-            throw new IllegalArgumentException("강좌를 생성할 권한이 없습니다.");
+            throw new CourseCreationDeniedException();
         }
 
         if (!categoryRepository.existsById(categoryId)) {
-            throw new IllegalArgumentException("존재하지 않는 카테고리 ID입니다.");
+            throw new CategoryNotFoundException();
         }
     }
 }

--- a/src/main/java/com/example/projectlxp/course/service/validator/CourseValidator.java
+++ b/src/main/java/com/example/projectlxp/course/service/validator/CourseValidator.java
@@ -4,6 +4,8 @@ import org.springframework.stereotype.Component;
 
 import com.example.projectlxp.category.repository.CategoryRepository;
 import com.example.projectlxp.course.repository.CourseRepository;
+import com.example.projectlxp.user.entity.Role;
+import com.example.projectlxp.user.entity.User;
 import com.example.projectlxp.user.repository.UserRepository;
 
 @Component
@@ -22,15 +24,13 @@ public class CourseValidator {
         this.categoryRepository = categoryRepository;
     }
 
-    public void validateCourseOwnership(Long courseId, Long userId) {
-        courseRepository
-                .findByIdAndInstructorId(courseId, userId)
-                .orElseThrow(() -> new IllegalArgumentException("사용자가 소유한 강좌가 아닙니다."));
-    }
-
     public void validateCourseCreation(Long categoryId, Long userId) {
-        if (!userRepository.existsById(userId)) {
-            throw new IllegalArgumentException("존재하지 않는 강사(User) ID입니다.");
+        User user =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 강사(User) ID입니다."));
+        if (user.getRole() != Role.INSTRUCTOR) {
+            throw new IllegalArgumentException("강좌를 생성할 권한이 없습니다.");
         }
 
         if (!categoryRepository.existsById(categoryId)) {

--- a/src/main/java/com/example/projectlxp/review/controller/ReviewController.java
+++ b/src/main/java/com/example/projectlxp/review/controller/ReviewController.java
@@ -5,6 +5,7 @@ import jakarta.validation.Valid;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -50,6 +51,7 @@ public class ReviewController {
         return BaseResponse.success(responseDTO);
     }
 
+    // 리뷰 삭제
     @DeleteMapping("/{reviewId}")
     public BaseResponse<Void> deleteReview(
             @PathVariable Long reviewId,
@@ -57,5 +59,19 @@ public class ReviewController {
             ) {
         reviewService.deleteReview(reviewId, tempUserId);
         return BaseResponse.success(null);
+    }
+
+    // 리뷰 수정
+    @PatchMapping("/{reviewId}") // ★ 2. "@PatchMapping"
+    public BaseResponse<ReviewResponseDTO> updateReview(
+            @PathVariable Long reviewId,
+            @Valid @RequestBody ReviewRequestDTO requestDTO,
+            // (임시) '본인 확인'을 위한 유저 ID
+            @RequestParam(defaultValue = "1") Long tempUserId) {
+
+        ReviewResponseDTO responseDTO =
+                reviewService.updateReview(reviewId, requestDTO, tempUserId);
+
+        return BaseResponse.success(responseDTO);
     }
 }

--- a/src/main/java/com/example/projectlxp/review/dto/ReviewRequestDTO.java
+++ b/src/main/java/com/example/projectlxp/review/dto/ReviewRequestDTO.java
@@ -16,5 +16,5 @@ public class ReviewRequestDTO {
 
     @Min(value = 1, message = "평점은 1점 이상이어야 합니다.")
     @Max(value = 5, message = "평점은 5점 이하이어야 합니다.")
-    private int rating;
+    private double rating;
 }

--- a/src/main/java/com/example/projectlxp/review/dto/ReviewResponseDTO.java
+++ b/src/main/java/com/example/projectlxp/review/dto/ReviewResponseDTO.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 public class ReviewResponseDTO {
     private Long reviewId;
     private String content;
-    private int rating;
+    private double rating;
     private String username;
     private LocalDateTime createdAt;
 

--- a/src/main/java/com/example/projectlxp/review/entity/Review.java
+++ b/src/main/java/com/example/projectlxp/review/entity/Review.java
@@ -43,7 +43,7 @@ public class Review extends BaseEntity {
     private String content;
 
     @Column(nullable = false, columnDefinition = "INT CHECK (rating >= 1 AND rating <= 5)")
-    private int rating;
+    private double rating;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
@@ -52,4 +52,9 @@ public class Review extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "course_id", nullable = false)
     private Course course;
+
+    public void updateReview(String newContent, double newRating) {
+        this.content = newContent;
+        this.rating = newRating;
+    }
 }

--- a/src/main/java/com/example/projectlxp/review/service/ReviewService.java
+++ b/src/main/java/com/example/projectlxp/review/service/ReviewService.java
@@ -8,7 +8,7 @@ import com.example.projectlxp.review.dto.ReviewResponseDTO;
 
 public interface ReviewService {
     /**
-     * 특정 강좌의 리뷰 목록을 페이징하여 조회. Interface에는 이 메서드 껍데기만 존재
+     * 특정 강좌의 리뷰 목록을 페이징하여 조회.
      *
      * @param courseId 조회할 강좌의 ID
      * @param pageable 페이징 및 정렬 정보 (page, size, sort)
@@ -33,4 +33,14 @@ public interface ReviewService {
      * @param userId (임시) 삭제를 요청한 유저의 ID
      */
     void deleteReview(Long reviewId, Long userId);
+
+    /**
+     * [ #45 ] 리뷰 수정
+     *
+     * @param reviewId 수정할 리뷰의 ID
+     * @param requestDTO 수정할 내용(content, rating)이 담긴 DTO
+     * @param userId (임시) 수정을 요청한 유저의 ID
+     * @return '수정 완료된' 리뷰의 상세 DTO
+     */
+    ReviewResponseDTO updateReview(Long reviewId, ReviewRequestDTO requestDTO, Long userId);
 }

--- a/src/main/java/com/example/projectlxp/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/example/projectlxp/review/service/ReviewServiceImpl.java
@@ -1,5 +1,6 @@
 package com.example.projectlxp.review.service;
 
+import com.example.projectlxp.global.error.CustomBusinessException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -38,7 +39,7 @@ public class ReviewServiceImpl implements ReviewService {
                         .findById(courseId)
                         .orElseThrow(
                                 () ->
-                                        new IllegalArgumentException(
+                                        new CustomBusinessException(
                                                 "해당 강좌를 찾을 수 없습니다. id=" + courseId));
 
         Page<Review> reviewPage = reviewRepository.findByCourse(course, pageable);
@@ -60,7 +61,7 @@ public class ReviewServiceImpl implements ReviewService {
                         .findById(userId)
                         .orElseThrow(
                                 () ->
-                                        new IllegalArgumentException(
+                                        new CustomBusinessException(
                                                 "해당 유저를 찾을 수 없습니다. id=" + userId));
 
         Course course =
@@ -68,17 +69,17 @@ public class ReviewServiceImpl implements ReviewService {
                         .findById(courseId)
                         .orElseThrow(
                                 () ->
-                                        new IllegalArgumentException(
+                                        new CustomBusinessException(
                                                 "해당 강좌를 찾을 수 없습니다. id=" + courseId));
 
         boolean isEnrolled = enrollmentRepository.existsByUserAndCourse(user, course);
         if (!isEnrolled) {
-            throw new RuntimeException("이 강좌를 수강한 학생만 리뷰를 작성할 수 있습니다.");
+            throw new CustomBusinessException("이 강좌를 수강한 학생만 리뷰를 작성할 수 있습니다.");
         }
 
         boolean hasReviewed = reviewRepository.existsByUserAndCourse(user, course);
         if (hasReviewed) {
-            throw new RuntimeException("이미 이 강좌에 대한 리뷰를 작성했습니다.");
+            throw new CustomBusinessException("이미 이 강좌에 대한 리뷰를 작성했습니다.");
         }
 
         Review newReview =
@@ -103,7 +104,7 @@ public class ReviewServiceImpl implements ReviewService {
                         .findById(userId)
                         .orElseThrow(
                                 () ->
-                                        new IllegalArgumentException(
+                                        new CustomBusinessException(
                                                 "해당 유저를 찾을 수 없습니다. id=" + userId));
 
         Review review =
@@ -111,7 +112,7 @@ public class ReviewServiceImpl implements ReviewService {
                         .findById(reviewId)
                         .orElseThrow(
                                 () ->
-                                        new IllegalArgumentException(
+                                        new CustomBusinessException(
                                                 "해당 리뷰를 찾을 수 없습니다. id=" + reviewId));
 
         this.checkReviewOwner(review, user);
@@ -136,7 +137,7 @@ public class ReviewServiceImpl implements ReviewService {
                         .findById(userId)
                         .orElseThrow(
                                 () ->
-                                        new IllegalArgumentException(
+                                        new CustomBusinessException(
                                                 "해당 유저를 찾을 수 없습니다. id=" + userId));
 
         Review review =
@@ -144,7 +145,7 @@ public class ReviewServiceImpl implements ReviewService {
                         .findById(reviewId)
                         .orElseThrow(
                                 () ->
-                                        new IllegalArgumentException(
+                                        new CustomBusinessException(
                                                 "해당 리뷰를 찾을 수 없습니다. id=" + reviewId));
 
         this.checkReviewOwner(review, user);

--- a/src/main/java/com/example/projectlxp/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/example/projectlxp/review/service/ReviewServiceImpl.java
@@ -1,6 +1,5 @@
 package com.example.projectlxp.review.service;
 
-import com.example.projectlxp.global.error.CustomBusinessException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -11,6 +10,7 @@ import com.example.projectlxp.course.repository.CourseRepository;
 import com.example.projectlxp.enrollment.repository.EnrollmentRepository;
 import com.example.projectlxp.global.dto.PageDTO;
 import com.example.projectlxp.global.dto.PageResponse;
+import com.example.projectlxp.global.error.CustomBusinessException;
 import com.example.projectlxp.review.dto.ReviewRequestDTO;
 import com.example.projectlxp.review.dto.ReviewResponseDTO;
 import com.example.projectlxp.review.entity.Review;

--- a/src/main/java/com/example/projectlxp/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/example/projectlxp/review/service/ReviewServiceImpl.java
@@ -51,11 +51,10 @@ public class ReviewServiceImpl implements ReviewService {
     }
 
     /** '리뷰 작성' 메서드 */
-    @Transactional // ★ '쓰기'용 트랜잭션 (readOnly = false)
+    @Transactional
     @Override
     public ReviewResponseDTO createReview(Long courseId, ReviewRequestDTO requestDTO, Long userId) {
 
-        // 1. 엔티티 조회
         User user =
                 userRepository
                         .findById(userId)
@@ -126,5 +125,32 @@ public class ReviewServiceImpl implements ReviewService {
 
             throw new RuntimeException("해당 리뷰에 대한 권한이 없습니다.");
         }
+    }
+
+    @Transactional
+    @Override
+    public ReviewResponseDTO updateReview(Long reviewId, ReviewRequestDTO requestDTO, Long userId) {
+
+        User user =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(
+                                () ->
+                                        new IllegalArgumentException(
+                                                "해당 유저를 찾을 수 없습니다. id=" + userId));
+
+        Review review =
+                reviewRepository
+                        .findById(reviewId)
+                        .orElseThrow(
+                                () ->
+                                        new IllegalArgumentException(
+                                                "해당 리뷰를 찾을 수 없습니다. id=" + reviewId));
+
+        this.checkReviewOwner(review, user);
+
+        review.updateReview(requestDTO.getContent(), requestDTO.getRating());
+
+        return new ReviewResponseDTO(review);
     }
 }

--- a/src/test/java/com/example/projectlxp/course/service/CourseServiceImplTest.java
+++ b/src/test/java/com/example/projectlxp/course/service/CourseServiceImplTest.java
@@ -67,4 +67,30 @@ class CourseServiceImplTest {
                 () -> assertEquals(1000, courseDTO.price()),
                 () -> assertNull(courseDTO.thumbnail()));
     }
+
+    @Test
+    void 단일_강좌를_조회한다() {
+        // given
+        User instructor = User.builder().name("testName").email("test@test.com").build();
+        Category category = Category.builder().name("testName").build();
+
+        Course course =
+                Course.builder()
+                        .title("testTitle")
+                        .description("testDescription")
+                        .level(CourseLevel.BEGINNER)
+                        .category(category)
+                        .instructor(instructor)
+                        .build();
+
+        // when
+        when(courseRepository.findByIdWithInstructorAndCategory(1L))
+                .thenReturn(Optional.of(course));
+        CourseDTO dto = courseService.searchCourse(1L).course();
+
+        // then
+        assertAll(
+                () -> assertEquals("testTitle", dto.title()),
+                () -> assertEquals("testDescription", dto.description()));
+    }
 }


### PR DESCRIPTION


## ❗️ 이슈 번호
Closes #45 

## 📝 작업 내용
1. Controller

PATCH /api/reviews/{reviewId} 엔드포인트를 추가.

@Valid 및 @RequestBody를 사용하여 '수정할 데이터'(ReviewRequestDTO)의 '유효성 검증'을 구현.

팀 표준에 따라 '성공' 시 BaseResponse를 직접 반환.

2. Service

updateReview 메서드를 추가.


3. Entity

'변경 감지'가 작동할 수 있도록, 엔티티 스스로 상태를 변경하는 public void updateReview(String content, int rating) 메서드를 추가.


## 💭 주의 사항
<img width="834" height="770" alt="image" src="https://github.com/user-attachments/assets/c3593adf-3887-4de5-9b96-902e610f467e" />
테스트 완료

## 💡 리뷰 포인트
Service의 checkReviewOwner가 올바르게 '재사용'되었는지 확인 부탁드립니다.
