### PR TITLE
[REFACTOR] 유저 삭제 시 알 수 없음 표시

### DIFF
--- a/src/main/java/com/example/projectlxp/review/controller/ReviewController.java
+++ b/src/main/java/com/example/projectlxp/review/controller/ReviewController.java
@@ -21,6 +21,8 @@ import com.example.projectlxp.review.service.ReviewService;
 
 import lombok.RequiredArgsConstructor;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/reviews")
@@ -29,7 +31,7 @@ public class ReviewController {
 
     // 강좌 별 리뷰 조회
     @GetMapping("/courses/{courseId}")
-    public PageResponse<ReviewResponseDTO> getReviewsByCourse(
+    public PageResponse<List<ReviewResponseDTO>> getReviewsByCourse(
             @PathVariable Long courseId, Pageable pageable) {
 
         return reviewService.getReviewsByCourse(courseId, pageable);

--- a/src/main/java/com/example/projectlxp/review/controller/ReviewController.java
+++ b/src/main/java/com/example/projectlxp/review/controller/ReviewController.java
@@ -1,5 +1,7 @@
 package com.example.projectlxp.review.controller;
 
+import java.util.List;
+
 import jakarta.validation.Valid;
 
 import org.springframework.data.domain.Pageable;
@@ -20,8 +22,6 @@ import com.example.projectlxp.review.dto.ReviewResponseDTO;
 import com.example.projectlxp.review.service.ReviewService;
 
 import lombok.RequiredArgsConstructor;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/example/projectlxp/review/dto/ReviewResponseDTO.java
+++ b/src/main/java/com/example/projectlxp/review/dto/ReviewResponseDTO.java
@@ -2,25 +2,19 @@ package com.example.projectlxp.review.dto;
 
 import java.time.LocalDateTime;
 
-import com.example.projectlxp.review.entity.Review;
-
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class ReviewResponseDTO {
     private Long reviewId;
     private String content;
     private double rating;
     private String username;
     private LocalDateTime createdAt;
-
-    public ReviewResponseDTO(Review review) {
-        this.reviewId = review.getId();
-        this.content = review.getContent();
-        this.rating = review.getRating();
-        this.username = (review.getUser().isDeleted()) ? "알 수 없음" : review.getUser().getName();
-        this.createdAt = review.getCreatedAt();
-    }
 }

--- a/src/main/java/com/example/projectlxp/review/dto/ReviewResponseDTO.java
+++ b/src/main/java/com/example/projectlxp/review/dto/ReviewResponseDTO.java
@@ -20,7 +20,7 @@ public class ReviewResponseDTO {
         this.reviewId = review.getId();
         this.content = review.getContent();
         this.rating = review.getRating();
-        this.username = review.getUser().getName();
+        this.username = (review.getUser().isDeleted()) ? "알 수 없음" : review.getUser().getName();
         this.createdAt = review.getCreatedAt();
     }
 }

--- a/src/main/java/com/example/projectlxp/review/repository/ReviewRepository.java
+++ b/src/main/java/com/example/projectlxp/review/repository/ReviewRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.example.projectlxp.course.entity.Course;
 import com.example.projectlxp.review.entity.Review;
 import com.example.projectlxp.user.entity.User;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
@@ -18,6 +19,8 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
      * @param pageable 페이징 및 정렬 정보
      * @return 페이징 처리된 리뷰 목록 (Page<Review>)
      */
+    @Query(value = "SELECT r FROM Review r LEFT JOIN FETCH r.user u WHERE r.course = :course",
+            countQuery = "SELECT COUNT(r) FROM Review r WHERE r.course = :course")
     Page<Review> findByCourse(Course course, Pageable pageable);
 
     /** 특정 유저가 특정 강좌에 대해 리뷰를 작성했는지 확인 */

--- a/src/main/java/com/example/projectlxp/review/repository/ReviewRepository.java
+++ b/src/main/java/com/example/projectlxp/review/repository/ReviewRepository.java
@@ -3,11 +3,11 @@ package com.example.projectlxp.review.repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.example.projectlxp.course.entity.Course;
 import com.example.projectlxp.review.entity.Review;
 import com.example.projectlxp.user.entity.User;
-import org.springframework.data.jpa.repository.Query;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
@@ -19,7 +19,8 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
      * @param pageable 페이징 및 정렬 정보
      * @return 페이징 처리된 리뷰 목록 (Page<Review>)
      */
-    @Query(value = "SELECT r FROM Review r LEFT JOIN FETCH r.user u WHERE r.course = :course",
+    @Query(
+            value = "SELECT r FROM Review r LEFT JOIN FETCH r.user u WHERE r.course = :course",
             countQuery = "SELECT COUNT(r) FROM Review r WHERE r.course = :course")
     Page<Review> findByCourse(Course course, Pageable pageable);
 

--- a/src/main/java/com/example/projectlxp/review/service/ReviewService.java
+++ b/src/main/java/com/example/projectlxp/review/service/ReviewService.java
@@ -1,12 +1,12 @@
 package com.example.projectlxp.review.service;
 
+import java.util.List;
+
 import org.springframework.data.domain.Pageable;
 
 import com.example.projectlxp.global.dto.PageResponse;
 import com.example.projectlxp.review.dto.ReviewRequestDTO;
 import com.example.projectlxp.review.dto.ReviewResponseDTO;
-
-import java.util.List;
 
 public interface ReviewService {
     /**

--- a/src/main/java/com/example/projectlxp/review/service/ReviewService.java
+++ b/src/main/java/com/example/projectlxp/review/service/ReviewService.java
@@ -6,6 +6,8 @@ import com.example.projectlxp.global.dto.PageResponse;
 import com.example.projectlxp.review.dto.ReviewRequestDTO;
 import com.example.projectlxp.review.dto.ReviewResponseDTO;
 
+import java.util.List;
+
 public interface ReviewService {
     /**
      * 특정 강좌의 리뷰 목록을 페이징하여 조회.
@@ -14,7 +16,7 @@ public interface ReviewService {
      * @param pageable 페이징 및 정렬 정보 (page, size, sort)
      * @return 페이징 처리된 리뷰 DTO 목록 (Page<ReviewResponseDto>)
      */
-    PageResponse<ReviewResponseDTO> getReviewsByCourse(Long courseId, Pageable pageable);
+    PageResponse<List<ReviewResponseDTO>> getReviewsByCourse(Long courseId, Pageable pageable);
 
     /**
      * 리뷰 작성.

--- a/src/main/java/com/example/projectlxp/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/example/projectlxp/review/service/ReviewServiceImpl.java
@@ -1,5 +1,7 @@
 package com.example.projectlxp.review.service;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -20,8 +22,6 @@ import com.example.projectlxp.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
 
-import java.util.List;
-
 @Service
 @RequiredArgsConstructor // "final이 붙은 필드의 생성자를 자동으로 만들어 줌(생성자 주입)"
 @Transactional(readOnly = true) // 조회 전용으로 읽기에 성능 최적화
@@ -35,7 +35,8 @@ public class ReviewServiceImpl implements ReviewService {
     private final EnrollmentRepository enrollmentRepository;
 
     @Override
-    public PageResponse<List<ReviewResponseDTO>> getReviewsByCourse(Long courseId, Pageable pageable) {
+    public PageResponse<List<ReviewResponseDTO>> getReviewsByCourse(
+            Long courseId, Pageable pageable) {
         Course course =
                 courseRepository
                         .findById(courseId)
@@ -45,18 +46,21 @@ public class ReviewServiceImpl implements ReviewService {
                                                 "해당 강좌를 찾을 수 없습니다. id=" + courseId));
 
         Page<Review> reviewPage = reviewRepository.findByCourse(course, pageable);
-        Page<ReviewResponseDTO> dtoPage = reviewPage.map(review -> {
-            String username = (review.getUser() == null || review.getUser().isDeleted())
-                    ? "알 수 없음"
-                    : review.getUser().getName();
-            return ReviewResponseDTO.builder()
-                    .reviewId(review.getId())
-                    .content(review.getContent())
-                    .rating(review.getRating())
-                    .username(username)
-                    .createdAt(review.getCreatedAt())
-                    .build();
-        });
+        Page<ReviewResponseDTO> dtoPage =
+                reviewPage.map(
+                        review -> {
+                            String username =
+                                    (review.getUser() == null || review.getUser().isDeleted())
+                                            ? "알 수 없음"
+                                            : review.getUser().getName();
+                            return ReviewResponseDTO.builder()
+                                    .reviewId(review.getId())
+                                    .content(review.getContent())
+                                    .rating(review.getRating())
+                                    .username(username)
+                                    .createdAt(review.getCreatedAt())
+                                    .build();
+                        });
         PageDTO pageInfo = PageDTO.of(dtoPage);
         return PageResponse.success(dtoPage.getContent(), pageInfo);
     }


### PR DESCRIPTION

## ❗️ 이슈 번호
Closes #52 

## 📝 작업 내용
Soft Delete' 아키텍처를 지원하기 위해 ReviewResponseDTO의 생성자 로직을 수정.

review.getUser()가 null인지 확인하는 대신, review.getUser().isDeleted() 플래그를 확인.

만약 유저가 'Soft Delete'된 상태(isDeleted() == true)라면, username 필드에 "알 수 없음"을 반환하도록 '방어 코드'를 추가.

## 💭 주의 사항
이 기능은 'User' 담당 팀원이 DELETE /api/users/{id} 요청 시, DB에서 DELETE하는 대신 is_deleted = true로 'Soft Delete'를 구현하는 것을 전제로 합니다.

'Review' 엔티티의 user_id는 nullable = false (NOT NULL) 상태를 유지

## 💡 리뷰 포인트
ReviewResponseDTO의 생성자에 'Soft Delete'(isDeleted())를 처리하는 '방어 코드'가 올바르게 적용되었는지 확인 부탁드립니다.
