### PR TITLE
[FEAT] 수강중인 강좌 숨기기 & 숨겨진 강좌 보이기 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.springframework.boot' version '3.5.7'
     id 'io.spring.dependency-management' version '1.1.7'
     id 'com.diffplug.spotless' version '8.0.0'
+    id 'jacoco'
 }
 
 group = 'com.example'
@@ -23,6 +24,24 @@ configurations {
 
 repositories {
     mavenCentral()
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+    finalizedBy 'jacocoTestReport'
+}
+
+jacoco {
+    toolVersion = "0.8.10"
+}
+
+// 리포트 생성
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true
+        html.required = true
+    }
 }
 
 dependencies {
@@ -55,10 +74,6 @@ dependencies {
 
 tasks.named('compileJava') {
     dependsOn 'spotlessApply'
-}
-
-tasks.named('test') {
-    useJUnitPlatform()
 }
 
 spotless {

--- a/src/main/java/com/example/projectlxp/enrollment/controller/EnrollmentController.java
+++ b/src/main/java/com/example/projectlxp/enrollment/controller/EnrollmentController.java
@@ -40,7 +40,7 @@ public class EnrollmentController {
     @GetMapping("/my")
     public BaseResponse<PagedEnrolledCourseDTO> getMyCourses(
             @RequestParam Long userId,
-            @RequestParam(required = false) Boolean hidden,
+            @RequestParam(defaultValue = "false") Boolean hidden,
             @PageableDefault Pageable pageable) {
         PagedEnrolledCourseDTO pagedEnrolledCourseDTO =
                 enrollmentService.getMyEnrolledCourses(userId, hidden, pageable);

--- a/src/main/java/com/example/projectlxp/enrollment/controller/EnrollmentController.java
+++ b/src/main/java/com/example/projectlxp/enrollment/controller/EnrollmentController.java
@@ -5,7 +5,9 @@ import jakarta.validation.Valid;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -13,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.example.projectlxp.enrollment.dto.request.CreateEnrollmentRequestDTO;
 import com.example.projectlxp.enrollment.dto.response.CreateEnrollmentResponseDTO;
+import com.example.projectlxp.enrollment.dto.response.EnrolledCourseDTO;
 import com.example.projectlxp.enrollment.dto.response.PagedEnrolledCourseDTO;
 import com.example.projectlxp.enrollment.service.EnrollmentService;
 import com.example.projectlxp.global.dto.BaseResponse;
@@ -36,9 +39,26 @@ public class EnrollmentController {
 
     @GetMapping("/my")
     public BaseResponse<PagedEnrolledCourseDTO> getMyCourses(
-            @RequestParam Long userId, @PageableDefault Pageable pageable) {
+            @RequestParam Long userId,
+            @RequestParam(required = false) Boolean hidden,
+            @PageableDefault Pageable pageable) {
         PagedEnrolledCourseDTO pagedEnrolledCourseDTO =
-                enrollmentService.getMyEnrolledCourses(userId, pageable);
+                enrollmentService.getMyEnrolledCourses(userId, hidden, pageable);
         return BaseResponse.success("수강중인 강좌 목록 조회를 성공했습니다.", pagedEnrolledCourseDTO);
+    }
+
+    @PutMapping("/{enrollmentId}/hide")
+    public BaseResponse<EnrolledCourseDTO> hideEnrollment(
+            @RequestParam Long userId, @PathVariable Long enrollmentId) {
+        return BaseResponse.success(
+                "수강중인 강좌가 성공적으로 숨겨졌습니다.", enrollmentService.hideEnrollment(userId, enrollmentId));
+    }
+
+    @PutMapping("/{enrollmentId}/unhide")
+    public BaseResponse<EnrolledCourseDTO> unhideEnrollment(
+            @RequestParam Long userId, @PathVariable Long enrollmentId) {
+        return BaseResponse.success(
+                "수강중인 강좌가 성공적으로 숨김 해제되었습니다 .",
+                enrollmentService.unhideEnrollment(userId, enrollmentId));
     }
 }

--- a/src/main/java/com/example/projectlxp/enrollment/controller/EnrollmentController.java
+++ b/src/main/java/com/example/projectlxp/enrollment/controller/EnrollmentController.java
@@ -58,7 +58,7 @@ public class EnrollmentController {
     public BaseResponse<EnrolledCourseDTO> unhideEnrollment(
             @RequestParam Long userId, @PathVariable Long enrollmentId) {
         return BaseResponse.success(
-                "수강중인 강좌가 성공적으로 숨김 해제되었습니다 .",
+                "수강중인 강좌가 성공적으로 숨김 해제되었습니다.",
                 enrollmentService.unhideEnrollment(userId, enrollmentId));
     }
 }

--- a/src/main/java/com/example/projectlxp/enrollment/dto/response/EnrolledCourseDTO.java
+++ b/src/main/java/com/example/projectlxp/enrollment/dto/response/EnrolledCourseDTO.java
@@ -18,6 +18,7 @@ public class EnrolledCourseDTO {
     private String courseTitle;
     private String thumbnail;
     private int progress;
+    private boolean isHidden;
 
     public static EnrolledCourseDTO from(Enrollment enrollment) {
         Course course = enrollment.getCourse();
@@ -26,6 +27,7 @@ public class EnrolledCourseDTO {
                 course.getId(),
                 course.getTitle(),
                 course.getThumbnail(),
-                enrollment.getProgress());
+                enrollment.getProgress(),
+                enrollment.isHidden());
     }
 }

--- a/src/main/java/com/example/projectlxp/enrollment/entity/Enrollment.java
+++ b/src/main/java/com/example/projectlxp/enrollment/entity/Enrollment.java
@@ -70,4 +70,12 @@ public class Enrollment extends BaseEntity {
 
     @OneToMany(mappedBy = "enrollment", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<LectureProgress> lectureProgresses = new ArrayList<>();
+
+    public void hide() {
+        isHidden = true;
+    }
+
+    public void unhide() {
+        isHidden = false;
+    }
 }

--- a/src/main/java/com/example/projectlxp/enrollment/entity/Enrollment.java
+++ b/src/main/java/com/example/projectlxp/enrollment/entity/Enrollment.java
@@ -80,10 +80,6 @@ public class Enrollment extends BaseEntity {
     }
 
     public static Enrollment create(User user, Course course, boolean isHidden) {
-        return Enrollment.builder()
-                .user(user)
-                .course(course)
-                .isHidden(isHidden)
-                .build();
+        return Enrollment.builder().user(user).course(course).isHidden(isHidden).build();
     }
 }

--- a/src/main/java/com/example/projectlxp/enrollment/entity/Enrollment.java
+++ b/src/main/java/com/example/projectlxp/enrollment/entity/Enrollment.java
@@ -31,7 +31,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
 @Entity
 @Table(
@@ -77,5 +77,13 @@ public class Enrollment extends BaseEntity {
 
     public void unhide() {
         isHidden = false;
+    }
+
+    public static Enrollment create(User user, Course course, boolean isHidden) {
+        return Enrollment.builder()
+                .user(user)
+                .course(course)
+                .isHidden(isHidden)
+                .build();
     }
 }

--- a/src/main/java/com/example/projectlxp/enrollment/repository/EnrollmentRepository.java
+++ b/src/main/java/com/example/projectlxp/enrollment/repository/EnrollmentRepository.java
@@ -16,7 +16,8 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
     @Query(
             value =
                     "SELECT e FROM Enrollment e JOIN FETCH e.course c WHERE e.user.id = :userId AND e.isHidden = :isHidden",
-            countQuery = "SELECT COUNT(e) FROM Enrollment e WHERE e.user.id = :userId AND e.isHidden = :isHidden")
+            countQuery =
+                    "SELECT COUNT(e) FROM Enrollment e WHERE e.user.id = :userId AND e.isHidden = :isHidden")
     Page<Enrollment> findVisibleByUserIdWithCourse(
             @Param("userId") Long userId, @Param("isHidden") Boolean isHidden, Pageable pageable);
 }

--- a/src/main/java/com/example/projectlxp/enrollment/repository/EnrollmentRepository.java
+++ b/src/main/java/com/example/projectlxp/enrollment/repository/EnrollmentRepository.java
@@ -16,7 +16,7 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
     @Query(
             value =
                     "SELECT e FROM Enrollment e JOIN FETCH e.course c WHERE e.user.id = :userId AND e.isHidden = :isHidden",
-            countQuery = "SELECT COUNT(e) FROM Enrollment e WHERE e.user.id = :userId")
+            countQuery = "SELECT COUNT(e) FROM Enrollment e WHERE e.user.id = :userId AND e.isHidden = :isHidden")
     Page<Enrollment> findVisibleByUserIdWithCourse(
             @Param("userId") Long userId, @Param("isHidden") Boolean isHidden, Pageable pageable);
 }

--- a/src/main/java/com/example/projectlxp/enrollment/repository/EnrollmentRepository.java
+++ b/src/main/java/com/example/projectlxp/enrollment/repository/EnrollmentRepository.java
@@ -14,7 +14,9 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
     boolean existsByUserAndCourse(User user, Course course);
 
     @Query(
-            value = "SELECT e FROM Enrollment e JOIN FETCH e.course c WHERE e.user.id = :userId",
+            value =
+                    "SELECT e FROM Enrollment e JOIN FETCH e.course c WHERE e.user.id = :userId AND e.isHidden = :isHidden",
             countQuery = "SELECT COUNT(e) FROM Enrollment e WHERE e.user.id = :userId")
-    Page<Enrollment> findByUserIdWithCourse(@Param("userId") Long userId, Pageable pageable);
+    Page<Enrollment> findVisibleByUserIdWithCourse(
+            @Param("userId") Long userId, @Param("isHidden") Boolean isHidden, Pageable pageable);
 }

--- a/src/main/java/com/example/projectlxp/enrollment/service/EnrollmentService.java
+++ b/src/main/java/com/example/projectlxp/enrollment/service/EnrollmentService.java
@@ -4,10 +4,15 @@ import org.springframework.data.domain.Pageable;
 
 import com.example.projectlxp.enrollment.dto.request.CreateEnrollmentRequestDTO;
 import com.example.projectlxp.enrollment.dto.response.CreateEnrollmentResponseDTO;
+import com.example.projectlxp.enrollment.dto.response.EnrolledCourseDTO;
 import com.example.projectlxp.enrollment.dto.response.PagedEnrolledCourseDTO;
 
 public interface EnrollmentService {
     CreateEnrollmentResponseDTO enrollCourse(Long userId, CreateEnrollmentRequestDTO requestDTO);
 
-    PagedEnrolledCourseDTO getMyEnrolledCourses(Long userId, Pageable pageable);
+    PagedEnrolledCourseDTO getMyEnrolledCourses(Long userId, Boolean isHidden, Pageable pageable);
+
+    EnrolledCourseDTO hideEnrollment(Long userId, Long enrollmentId);
+
+    EnrolledCourseDTO unhideEnrollment(Long userId, Long enrollmentId);
 }

--- a/src/main/java/com/example/projectlxp/enrollment/service/EnrollmentServiceImpl.java
+++ b/src/main/java/com/example/projectlxp/enrollment/service/EnrollmentServiceImpl.java
@@ -67,7 +67,7 @@ public class EnrollmentServiceImpl implements EnrollmentService {
                     HttpStatus.CONFLICT);
         }
 
-        Enrollment enrollment = Enrollment.builder().user(user).course(course).build();
+        Enrollment enrollment = Enrollment.create(user, course, false);
 
         Enrollment savedEnrollment = enrollmentRepository.save(enrollment);
         return CreateEnrollmentResponseDTO.from(savedEnrollment);

--- a/src/main/java/com/example/projectlxp/enrollment/service/EnrollmentServiceImpl.java
+++ b/src/main/java/com/example/projectlxp/enrollment/service/EnrollmentServiceImpl.java
@@ -14,6 +14,7 @@ import com.example.projectlxp.enrollment.dto.response.EnrolledCourseDTO;
 import com.example.projectlxp.enrollment.dto.response.PagedEnrolledCourseDTO;
 import com.example.projectlxp.enrollment.entity.Enrollment;
 import com.example.projectlxp.enrollment.repository.EnrollmentRepository;
+import com.example.projectlxp.enrollment.service.validator.EnrollmentValidator;
 import com.example.projectlxp.global.error.CustomBusinessException;
 import com.example.projectlxp.user.entity.User;
 import com.example.projectlxp.user.repository.UserRepository;
@@ -25,14 +26,17 @@ public class EnrollmentServiceImpl implements EnrollmentService {
     private final EnrollmentRepository enrollmentRepository;
     private final UserRepository userRepository;
     private final CourseRepository courseRepository;
+    private final EnrollmentValidator enrollmentValidator;
 
     public EnrollmentServiceImpl(
             EnrollmentRepository enrollmentRepository,
             UserRepository userRepository,
-            CourseRepository courseRepository) {
+            CourseRepository courseRepository,
+            EnrollmentValidator enrollmentValidator) {
         this.enrollmentRepository = enrollmentRepository;
         this.userRepository = userRepository;
         this.courseRepository = courseRepository;
+        this.enrollmentValidator = enrollmentValidator;
     }
 
     @Override
@@ -70,7 +74,8 @@ public class EnrollmentServiceImpl implements EnrollmentService {
     }
 
     @Override
-    public PagedEnrolledCourseDTO getMyEnrolledCourses(Long userId, Pageable pageable) {
+    public PagedEnrolledCourseDTO getMyEnrolledCourses(
+            Long userId, Boolean isHidden, Pageable pageable) {
         User user =
                 userRepository
                         .findById(userId)
@@ -78,8 +83,46 @@ public class EnrollmentServiceImpl implements EnrollmentService {
                                 () -> new CustomBusinessException("존재하지 않는 회원입니다. ID: " + userId));
 
         Page<Enrollment> enrollmentPage =
-                enrollmentRepository.findByUserIdWithCourse(user.getId(), pageable);
+                enrollmentRepository.findVisibleByUserIdWithCourse(
+                        user.getId(), isHidden, pageable);
+
         Page<EnrolledCourseDTO> enrolledCourseDTOPage = enrollmentPage.map(EnrolledCourseDTO::from);
         return PagedEnrolledCourseDTO.from(enrolledCourseDTOPage);
+    }
+
+    @Override
+    @Transactional
+    public EnrolledCourseDTO hideEnrollment(Long userId, Long enrollmentId) {
+        Enrollment enrollment =
+                enrollmentRepository
+                        .findById(enrollmentId)
+                        .orElseThrow(
+                                () ->
+                                        new CustomBusinessException(
+                                                "존재하지 않는 수강신청입니다. ID: " + enrollmentId,
+                                                HttpStatus.NOT_FOUND));
+
+        enrollmentValidator.validateOwnership(userId, enrollment);
+        enrollment.hide();
+
+        return EnrolledCourseDTO.from(enrollment);
+    }
+
+    @Override
+    @Transactional
+    public EnrolledCourseDTO unhideEnrollment(Long userId, Long enrollmentId) {
+        Enrollment enrollment =
+                enrollmentRepository
+                        .findById(enrollmentId)
+                        .orElseThrow(
+                                () ->
+                                        new CustomBusinessException(
+                                                "존재하지 않는 수강신청입니다. ID: " + enrollmentId,
+                                                HttpStatus.NOT_FOUND));
+
+        enrollmentValidator.validateOwnership(userId, enrollment);
+        enrollment.unhide();
+
+        return EnrolledCourseDTO.from(enrollment);
     }
 }

--- a/src/main/java/com/example/projectlxp/enrollment/service/validator/EnrollmentValidator.java
+++ b/src/main/java/com/example/projectlxp/enrollment/service/validator/EnrollmentValidator.java
@@ -1,0 +1,18 @@
+package com.example.projectlxp.enrollment.service.validator;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+import com.example.projectlxp.enrollment.entity.Enrollment;
+import com.example.projectlxp.global.error.CustomBusinessException;
+
+@Component
+public class EnrollmentValidator {
+    public void validateOwnership(Long userId, Enrollment enrollment) {
+        if (!enrollment.getUser().getId().equals(userId)) {
+            throw new CustomBusinessException(
+                    "수강신청을 숨길 권한이 없습니다. 회원 ID: " + userId + ", 수강신청 ID: " + enrollment.getId(),
+                    HttpStatus.FORBIDDEN);
+        }
+    }
+}

--- a/src/main/java/com/example/projectlxp/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/projectlxp/global/config/SecurityConfig.java
@@ -26,7 +26,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(
                         authorize ->
                                 authorize
-                                        .requestMatchers("/api/join")
+                                        .requestMatchers("/**")
                                         .permitAll() // 회원가입 경로는 누구나
                                         .anyRequest()
                                         .authenticated() // 그 외 모든 요청은 인증 필요

--- a/src/main/java/com/example/projectlxp/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/projectlxp/global/config/SecurityConfig.java
@@ -26,7 +26,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(
                         authorize ->
                                 authorize
-                                        .requestMatchers("/**")
+                                        .requestMatchers("/api/join")
                                         .permitAll() // 회원가입 경로는 누구나
                                         .anyRequest()
                                         .authenticated() // 그 외 모든 요청은 인증 필요

--- a/src/test/java/com/example/projectlxp/enrollment/controller/EnrollmentControllerTest.java
+++ b/src/test/java/com/example/projectlxp/enrollment/controller/EnrollmentControllerTest.java
@@ -210,7 +210,7 @@ class EnrollmentControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("200"))
                 .andExpect(jsonPath("$.code").value("OK"))
-                .andExpect(jsonPath("$.message").value("수강중인 강좌가 성공적으로 숨김 해제되었습니다 ."))
+                .andExpect(jsonPath("$.message").value("수강중인 강좌가 성공적으로 숨김 해제되었습니다."))
                 .andExpect(jsonPath("$.data.enrollmentId").value(enrollmentId))
                 .andExpect(jsonPath("$.data.hidden").value(false));
     }

--- a/src/test/java/com/example/projectlxp/enrollment/controller/EnrollmentControllerTest.java
+++ b/src/test/java/com/example/projectlxp/enrollment/controller/EnrollmentControllerTest.java
@@ -1,10 +1,12 @@
 package com.example.projectlxp.enrollment.controller;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -15,10 +17,12 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -30,7 +34,9 @@ import com.example.projectlxp.enrollment.service.EnrollmentService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @WithMockUser
+@ActiveProfiles("test")
 @WebMvcTest(EnrollmentController.class)
+@AutoConfigureMockMvc(addFilters = false)
 class EnrollmentControllerTest {
     @Autowired private MockMvc mockMvc;
 
@@ -38,12 +44,12 @@ class EnrollmentControllerTest {
 
     @Autowired private ObjectMapper objectMapper;
 
-    @DisplayName("강좌 수강신청 API 호출에 성공한다.")
+    @DisplayName("강좌 수강신청을 성공한다.")
     @Test
     void enrollCourse_Success() throws Exception {
         // given
-        long courseId = 1L;
-        long userId = 1L;
+        Long courseId = 1L;
+        Long userId = 1L;
 
         CreateEnrollmentRequestDTO request =
                 CreateEnrollmentRequestDTO.builder().courseId(courseId).build();
@@ -92,30 +98,32 @@ class EnrollmentControllerTest {
                 .andExpect(status().isBadRequest());
     }
 
-    @DisplayName("내 수강 목록을 성공적으로 조회한다.")
+    @WithMockUser
+    @DisplayName("숨김 처리 상태가 수강 목록을 제외하고 내 수강 목록을 성공적으로 조회한다.")
     @Test
     void getMyCourses_Success() throws Exception {
         // given
         Long userId = 1L;
-        EnrolledCourseDTO courseDTO =
-                EnrolledCourseDTO.builder()
-                        .enrollmentId(1L)
-                        .courseId(101L)
-                        .courseTitle("Java Basics")
-                        .progress(0)
-                        .build();
 
-        List<EnrolledCourseDTO> dtoList = List.of(courseDTO);
+        EnrolledCourseDTO courseDTO1 = createEnrollment("Java Basics", false);
+        EnrolledCourseDTO courseDTO2 = createEnrollment("Spring Framework", true);
+        EnrolledCourseDTO courseDTO3 = createEnrollment("Database Essentials", false);
+
+        // 숨김(false)만 필터링된 결과라고 가정
+        List<EnrolledCourseDTO> filteredList = List.of(courseDTO1, courseDTO3);
+
         PagedEnrolledCourseDTO fakePageResponse =
                 PagedEnrolledCourseDTO.builder()
-                        .enrolledCourseDTOList(dtoList)
+                        .enrolledCourseDTOList(filteredList)
                         .totalPages(1)
-                        .totalElements(1L)
+                        .totalElements((long) filteredList.size())
                         .isFirst(true)
                         .isLast(true)
                         .build();
 
-        given(enrollmentService.getMyEnrolledCourses(any(Long.class), any(Pageable.class)))
+        given(
+                        enrollmentService.getMyEnrolledCourses(
+                                any(Long.class), eq(false), any(Pageable.class)))
                 .willReturn(fakePageResponse);
 
         // when // then
@@ -124,16 +132,96 @@ class EnrollmentControllerTest {
                                 .param("userId", String.valueOf(userId))
                                 .param("page", "0")
                                 .param("size", "10")
+                                .param("hidden", "false")
                                 .accept(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("200"))
                 .andExpect(jsonPath("$.code").value("OK"))
                 .andExpect(jsonPath("$.message").value("수강중인 강좌 목록 조회를 성공했습니다."))
-                .andExpect(jsonPath("$.data.totalElements").value(1))
+                .andExpect(jsonPath("$.data.totalElements").value(2))
                 .andExpect(jsonPath("$.data.totalPages").value(1))
                 .andExpect(
                         jsonPath("$.data.enrolledCourseDTOList[0].courseTitle")
-                                .value("Java Basics"));
+                                .value("Java Basics"))
+                .andExpect(
+                        jsonPath("$.data.enrolledCourseDTOList[1].courseTitle")
+                                .value("Database Essentials"));
+    }
+
+    @WithMockUser
+    @DisplayName("수강 강좌 숨김 처리 API 성공")
+    @Test
+    void hideEnrollment_Success() throws Exception {
+        // given
+        Long userId = 1L;
+        Long enrollmentId = 10L;
+
+        EnrolledCourseDTO responseDTO =
+                EnrolledCourseDTO.builder()
+                        .enrollmentId(enrollmentId)
+                        .courseId(101L)
+                        .courseTitle("Java Basics")
+                        .isHidden(true)
+                        .progress(0)
+                        .build();
+
+        given(enrollmentService.hideEnrollment(userId, enrollmentId)).willReturn(responseDTO);
+
+        // when // then
+        mockMvc.perform(
+                        put("/enrollments/{enrollmentId}/hide", enrollmentId)
+                                .with(csrf())
+                                .param("userId", String.valueOf(userId))
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("200"))
+                .andExpect(jsonPath("$.code").value("OK"))
+                .andExpect(jsonPath("$.message").value("수강중인 강좌가 성공적으로 숨겨졌습니다."))
+                .andExpect(jsonPath("$.data.enrollmentId").value(enrollmentId))
+                .andExpect(jsonPath("$.data.hidden").value(true));
+    }
+
+    @WithMockUser
+    @DisplayName("수강 강좌 숨김 해제 API 성공")
+    @Test
+    void unhideEnrollment_Success() throws Exception {
+        // given
+        Long userId = 1L;
+        Long enrollmentId = 10L;
+
+        EnrolledCourseDTO responseDTO =
+                EnrolledCourseDTO.builder()
+                        .enrollmentId(enrollmentId)
+                        .courseId(101L)
+                        .courseTitle("Java Basics")
+                        .isHidden(false)
+                        .progress(0)
+                        .build();
+
+        given(enrollmentService.unhideEnrollment(userId, enrollmentId)).willReturn(responseDTO);
+
+        // when // then
+        mockMvc.perform(
+                        put("/enrollments/{enrollmentId}/unhide", enrollmentId)
+                                .with(csrf())
+                                .param("userId", String.valueOf(userId))
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("200"))
+                .andExpect(jsonPath("$.code").value("OK"))
+                .andExpect(jsonPath("$.message").value("수강중인 강좌가 성공적으로 숨김 해제되었습니다 ."))
+                .andExpect(jsonPath("$.data.enrollmentId").value(enrollmentId))
+                .andExpect(jsonPath("$.data.hidden").value(false));
+    }
+
+    private static EnrolledCourseDTO createEnrollment(String title, boolean isHidden) {
+        return EnrolledCourseDTO.builder()
+                .enrollmentId(1L)
+                .courseId(101L)
+                .courseTitle(title)
+                .progress(0)
+                .isHidden(isHidden)
+                .build();
     }
 }

--- a/src/test/java/com/example/projectlxp/enrollment/repository/EnrollmentRepositoryTest.java
+++ b/src/test/java/com/example/projectlxp/enrollment/repository/EnrollmentRepositoryTest.java
@@ -173,6 +173,6 @@ class EnrollmentRepositoryTest {
     }
 
     private Enrollment createEnrollment(User user, Course course) {
-        return Enrollment.builder().user(user).course(course).build();
+        return Enrollment.create(user, course, false);
     }
 }

--- a/src/test/java/com/example/projectlxp/enrollment/repository/EnrollmentRepositoryTest.java
+++ b/src/test/java/com/example/projectlxp/enrollment/repository/EnrollmentRepositoryTest.java
@@ -80,7 +80,7 @@ class EnrollmentRepositoryTest {
         // when
         List<Enrollment> enrollments =
                 enrollmentRepository
-                        .findByUserIdWithCourse(student.getId(), Pageable.unpaged())
+                        .findVisibleByUserIdWithCourse(student.getId(), false, Pageable.unpaged())
                         .getContent();
 
         // then
@@ -98,12 +98,13 @@ class EnrollmentRepositoryTest {
 
         // when
         Page<Enrollment> enrollmentPage =
-                enrollmentRepository.findByUserIdWithCourse(student.getId(), Pageable.unpaged());
+                enrollmentRepository.findVisibleByUserIdWithCourse(
+                        student.getId(), false, Pageable.unpaged());
 
         // then
         assertThat(enrollmentPage).isNotNull();
         assertThat(enrollmentPage.getTotalElements()).isEqualTo(0);
-        assertThat(enrollmentPage.getContent()).isEmpty(); // getContent().hasSize(0)과 동일
+        assertThat(enrollmentPage.getContent()).isEmpty();
         assertThat(enrollmentPage.isEmpty()).isTrue();
     }
 
@@ -130,7 +131,8 @@ class EnrollmentRepositoryTest {
         // when
         Pageable pageable = PageRequest.of(1, 3);
         Page<Enrollment> page =
-                enrollmentRepository.findByUserIdWithCourse(student.getId(), pageable);
+                enrollmentRepository.findVisibleByUserIdWithCourse(
+                        student.getId(), false, pageable);
 
         // then
         assertThat(page.getContent()).hasSize(2);

--- a/src/test/java/com/example/projectlxp/enrollment/service/EnrollmentServiceImplTest.java
+++ b/src/test/java/com/example/projectlxp/enrollment/service/EnrollmentServiceImplTest.java
@@ -288,7 +288,7 @@ class EnrollmentServiceImplTest {
     }
 
     private Enrollment createEnrollment(User user, Course course, boolean isHidden) {
-        return Enrollment.builder().user(user).course(course).isHidden(isHidden).build();
+        return Enrollment.create(user, course, isHidden);
     }
 
     private Enrollment createEnrollment(User user, Course course) {

--- a/src/test/java/com/example/projectlxp/enrollment/service/EnrollmentServiceImplTest.java
+++ b/src/test/java/com/example/projectlxp/enrollment/service/EnrollmentServiceImplTest.java
@@ -1,13 +1,17 @@
 package com.example.projectlxp.enrollment.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import java.util.List;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.ActiveProfiles;
 
 import com.example.projectlxp.category.entity.Category;
@@ -17,8 +21,11 @@ import com.example.projectlxp.course.entity.CourseLevel;
 import com.example.projectlxp.course.repository.CourseRepository;
 import com.example.projectlxp.enrollment.dto.request.CreateEnrollmentRequestDTO;
 import com.example.projectlxp.enrollment.dto.response.CreateEnrollmentResponseDTO;
+import com.example.projectlxp.enrollment.dto.response.EnrolledCourseDTO;
+import com.example.projectlxp.enrollment.dto.response.PagedEnrolledCourseDTO;
 import com.example.projectlxp.enrollment.entity.Enrollment;
 import com.example.projectlxp.enrollment.repository.EnrollmentRepository;
+import com.example.projectlxp.global.error.CustomBusinessException;
 import com.example.projectlxp.user.entity.Role;
 import com.example.projectlxp.user.entity.User;
 import com.example.projectlxp.user.repository.UserRepository;
@@ -80,6 +87,175 @@ class EnrollmentServiceImplTest {
                 .hasMessage("이미 등록된 강좌입니다. 회원 ID: " + user2.getId() + ", 강좌 ID: " + course.getId());
     }
 
+    @DisplayName("숨김 처리된 강좌를 제외하고 수강중인 강좌를 숨김 처리한다.")
+    @Test
+    void shouldHideEnrolledCourse() {
+        // given
+        User user1 = userRepository.save(createUser("test1@test.com"));
+        Category category = categoryRepository.save(createCategory());
+        Course course = courseRepository.save(createCourse(user1, category));
+
+        User user2 = userRepository.save(createUser("test2@test.com"));
+        Enrollment enrollment = createEnrollment(user2, course, false);
+        enrollmentRepository.save(enrollment);
+
+        // when
+        EnrolledCourseDTO enrolledCourseDTO =
+                enrollmentService.hideEnrollment(user2.getId(), enrollment.getId());
+
+        // then
+        assertThat(enrolledCourseDTO)
+                .extracting("enrollmentId", "isHidden")
+                .contains(enrollment.getId(), true);
+    }
+
+    @DisplayName("숨김 처리된 강좌를 제외하고 수강중인 강좌를 조회한다.")
+    @Test
+    void shouldShowEnrolledCourse() {
+        // given
+        User user1 = userRepository.save(createUser("test1@test.com"));
+        Category category = categoryRepository.save(createCategory());
+        Course course1 = courseRepository.save(createCourse("Course 1", user1, category));
+        Course course2 = courseRepository.save(createCourse("Course 2", user1, category));
+        Course course3 = courseRepository.save(createCourse("Course 3", user1, category));
+
+        User user2 = userRepository.save(createUser("test2@test.com"));
+        Enrollment enrollment1 = createEnrollment(user2, course1, false);
+        Enrollment enrollment2 = createEnrollment(user2, course2, true);
+        Enrollment enrollment3 = createEnrollment(user2, course3, false);
+
+        enrollmentRepository.saveAll(List.of(enrollment1, enrollment2, enrollment3));
+
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        PagedEnrolledCourseDTO result =
+                enrollmentService.getMyEnrolledCourses(user2.getId(), false, pageable);
+
+        // then
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        assertThat(result.getEnrolledCourseDTOList().size()).isEqualTo(2);
+
+        List<Long> enrollmentIds =
+                result.getEnrolledCourseDTOList().stream()
+                        .map(EnrolledCourseDTO::getEnrollmentId) // DTO에 맞게 수정
+                        .toList();
+
+        assertThat(enrollmentIds)
+                .containsExactlyInAnyOrder(enrollment1.getId(), enrollment3.getId());
+    }
+
+    @DisplayName("숨김 처리된 수강중인 강좌를 다시 보이게 처리한다.")
+    @Test
+    void shouldUnHideEnrolledCourse() {
+        // given
+        User user1 = userRepository.save(createUser("test1@test.com"));
+        Category category = categoryRepository.save(createCategory());
+        Course course = courseRepository.save(createCourse(user1, category));
+
+        User user2 = userRepository.save(createUser("test2@test.com"));
+        Enrollment enrollment = createEnrollment(user2, course);
+        enrollmentRepository.save(enrollment);
+
+        // when
+        EnrolledCourseDTO enrolledCourseDTO =
+                enrollmentService.unhideEnrollment(user2.getId(), enrollment.getId());
+
+        // then
+        assertThat(enrolledCourseDTO)
+                .extracting("enrollmentId", "isHidden")
+                .contains(enrollment.getId(), false);
+    }
+
+    @DisplayName("존재하지 않는 회원ID로 수강 신청을 시도하면 예외가 발생한다.")
+    @Test
+    void enrollCourse_throwsException_whenUserNotFound() {
+        // given
+        User courseOwner = userRepository.save(createUser("owner@test.com"));
+        Category category = categoryRepository.save(createCategory());
+        Course course = courseRepository.save(createCourse(courseOwner, category));
+
+        Long nonExistentUserId = 9999L;
+        CreateEnrollmentRequestDTO requestDTO = new CreateEnrollmentRequestDTO(course.getId());
+
+        // when // then
+        assertThatThrownBy(
+                        () -> {
+                            enrollmentService.enrollCourse(nonExistentUserId, requestDTO);
+                        })
+                .isInstanceOf(CustomBusinessException.class)
+                .hasMessageContaining("존재하지 않는 회원입니다."); // (서비스의 실제 예외 메시지 확인)
+    }
+
+    @DisplayName("존재하지 않는 회원ID로 수강 강좌 조회를 시도하면 예외가 발생한다.")
+    @Test
+    void getMyEnrolledCourses_throwsException_whenUserNotFound() {
+        // given
+        Long nonExistentUserId = 9999L; // DB에 절대 존재하지 않을 ID
+        Pageable pageable = PageRequest.of(0, 10); // 페이징 파라미터
+
+        // when // then
+        assertThatThrownBy(
+                        () -> {
+                            enrollmentService.getMyEnrolledCourses(
+                                    nonExistentUserId, false, pageable);
+                        })
+                .isInstanceOf(CustomBusinessException.class)
+                .hasMessageContaining("존재하지 않는 회원입니다. ID: " + nonExistentUserId);
+    }
+
+    @DisplayName("존재하지 않는 강좌ID로 수강 신청을 시도하면 예외가 발생한다.")
+    @Test
+    void enrollCourse_throwsException_whenCourseNotFound() {
+        // given
+        User user = userRepository.save(createUser("test1@test.com"));
+        Long nonExistentCourseId = 9999L;
+        CreateEnrollmentRequestDTO requestDTO = new CreateEnrollmentRequestDTO(nonExistentCourseId);
+
+        // when // then
+        assertThatThrownBy(
+                        () -> {
+                            enrollmentService.enrollCourse(user.getId(), requestDTO);
+                        })
+                .isInstanceOf(CustomBusinessException.class)
+                .hasMessageContaining("존재하지 않는 강좌입니다. ID: " + requestDTO.getCourseId());
+    }
+
+    @DisplayName("존재하지 않는 수강ID로 숨김 처리를 시도하면 예외가 발생한다.")
+    @Test
+    void hideEnrollment_throwsException_whenEnrollmentNotFound() {
+        // given
+        User user = userRepository.save(createUser("test1@test.com"));
+        Long nonExistentEnrollmentId = 9999L; // 존재하지 않는 수강 ID
+
+        // when // then
+        assertThatThrownBy(
+                        () -> {
+                            enrollmentService.hideEnrollment(user.getId(), nonExistentEnrollmentId);
+                        })
+                .isInstanceOf(CustomBusinessException.class)
+                .hasMessageContaining(
+                        "존재하지 않는 수강신청입니다. ID: " + nonExistentEnrollmentId); // (실제 예외 메시지에 맞게 수정)
+    }
+
+    @DisplayName("존재하지 않는 수강ID로 숨김 해제 처리를 시도하면 예외가 발생한다.")
+    @Test
+    void unhideEnrollment_throwsException_whenEnrollmentNotFound() {
+        // given
+        User user = userRepository.save(createUser("test1@test.com"));
+        Long nonExistentEnrollmentId = 9999L; // 존재하지 않는 수강 ID
+
+        // when // then
+        assertThatThrownBy(
+                        () -> {
+                            enrollmentService.unhideEnrollment(
+                                    user.getId(), nonExistentEnrollmentId);
+                        })
+                .isInstanceOf(CustomBusinessException.class)
+                .hasMessageContaining(
+                        "존재하지 않는 수강신청입니다. ID: " + nonExistentEnrollmentId); // (실제 예외 메시지에 맞게 수정)
+    }
+
     private User createUser(String email) {
         return User.builder()
                 .role(Role.STUDENT)
@@ -98,11 +274,24 @@ class EnrollmentServiceImplTest {
                 .build();
     }
 
+    private Course createCourse(String title, User instructor, Category category) {
+        return Course.builder()
+                .title(title)
+                .level(CourseLevel.BEGINNER)
+                .instructor(instructor)
+                .category(category)
+                .build();
+    }
+
     private Category createCategory() {
         return Category.builder().name("프로그래밍").build();
     }
 
+    private Enrollment createEnrollment(User user, Course course, boolean isHidden) {
+        return Enrollment.builder().user(user).course(course).isHidden(isHidden).build();
+    }
+
     private Enrollment createEnrollment(User user, Course course) {
-        return Enrollment.builder().user(user).course(course).build();
+        return createEnrollment(user, course, false);
     }
 }

--- a/src/test/java/com/example/projectlxp/enrollment/service/validator/EnrollmentValidatorTest.java
+++ b/src/test/java/com/example/projectlxp/enrollment/service/validator/EnrollmentValidatorTest.java
@@ -86,7 +86,7 @@ class EnrollmentValidatorTest {
     }
 
     private Enrollment createEnrollment(User user, Course course, boolean isHidden) {
-        return Enrollment.builder().user(user).course(course).isHidden(isHidden).build();
+        return Enrollment.create(user, course, isHidden);
     }
 
     private Enrollment createEnrollment(User user, Course course) {

--- a/src/test/java/com/example/projectlxp/enrollment/service/validator/EnrollmentValidatorTest.java
+++ b/src/test/java/com/example/projectlxp/enrollment/service/validator/EnrollmentValidatorTest.java
@@ -1,0 +1,95 @@
+package com.example.projectlxp.enrollment.service.validator;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.example.projectlxp.category.entity.Category;
+import com.example.projectlxp.category.repository.CategoryRepository;
+import com.example.projectlxp.course.entity.Course;
+import com.example.projectlxp.course.entity.CourseLevel;
+import com.example.projectlxp.course.repository.CourseRepository;
+import com.example.projectlxp.enrollment.entity.Enrollment;
+import com.example.projectlxp.enrollment.repository.EnrollmentRepository;
+import com.example.projectlxp.global.error.CustomBusinessException;
+import com.example.projectlxp.user.entity.Role;
+import com.example.projectlxp.user.entity.User;
+import com.example.projectlxp.user.repository.UserRepository;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class EnrollmentValidatorTest {
+    @Autowired private EnrollmentValidator enrollmentValidator;
+    @Autowired private EnrollmentRepository enrollmentRepository;
+    @Autowired private UserRepository userRepository;
+    @Autowired private CourseRepository courseRepository;
+    @Autowired private CategoryRepository categoryRepository;
+
+    @AfterEach
+    void tearDown() {
+        enrollmentRepository.deleteAllInBatch();
+        courseRepository.deleteAllInBatch();
+        categoryRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("수강 목록에 대한 권한은 본인만 있다.")
+    @Test
+    void validateOwnership_throwsException_whenNotOwner() {
+        // given
+        User user1 = userRepository.save(createUser("test1@test.com"));
+        Category category = categoryRepository.save(createCategory());
+        Course course = courseRepository.save(createCourse(user1, category));
+
+        User user2 = userRepository.save(createUser("test2@test.com"));
+        Enrollment enrollment = enrollmentRepository.save(createEnrollment(user2, course));
+        User user3 = userRepository.save(createUser("test3@test.com"));
+
+        // when // then
+        assertThatThrownBy(
+                        () -> {
+                            enrollmentValidator.validateOwnership(user3.getId(), enrollment);
+                        })
+                .isInstanceOf(CustomBusinessException.class)
+                .hasMessage(
+                        "수강신청을 숨길 권한이 없습니다. 회원 ID: "
+                                + user3.getId()
+                                + ", 수강신청 ID: "
+                                + enrollment.getId());
+    }
+
+    private User createUser(String email) {
+        return User.builder()
+                .role(Role.STUDENT)
+                .name("테스트유저")
+                .email(email)
+                .hashedPassword("hashedPassword123!")
+                .build();
+    }
+
+    private Course createCourse(User instructor, Category category) {
+        return Course.builder()
+                .title("테스트 강좌")
+                .level(CourseLevel.BEGINNER)
+                .instructor(instructor)
+                .category(category)
+                .build();
+    }
+
+    private Category createCategory() {
+        return Category.builder().name("프로그래밍").build();
+    }
+
+    private Enrollment createEnrollment(User user, Course course, boolean isHidden) {
+        return Enrollment.builder().user(user).course(course).isHidden(isHidden).build();
+    }
+
+    private Enrollment createEnrollment(User user, Course course) {
+        return createEnrollment(user, course, false);
+    }
+}


### PR DESCRIPTION
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->

## ❗️ 이슈 번호
#39 

## 📝 작업 내용
- Enrollment 도메인의 '수강 강좌 숨기기' (hideEnrollment) API를 구현했습니다.
- Enrollment 도메인의 '숨겨진 강좌 다시 보이기' (unhideEnrollment) API를 구현했습니다.
- getMyEnrolledCourses API가 숨김 처리된 강좌를 제외하고 조회하도록 수정했습니다.
- 테스트 커버리지 측정을 위해 build.gradle에 JaCoCo 플러그인을 설정했습니다.
- 위 기능들을 포함한 Enrollment 도메인의 서비스, 컨트롤러에 대한 테스트 코드를 작성했습니다.

## 💭 주의 사항
- DB 스키마 변경: Enrollment 엔티티에 isHidden (또는 유사한) 컬럼이 추가되었습니다.
- Gradle 변경: build.gradle에 JaCoCo 의존성이 추가되었습니다. Gradle 리프레시 후 빌드/테스트를 진행해 주세요.

## 💡 리뷰 포인트
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->
