### PR TITLE
[FEAT] 강좌 삭제 API 구현

### DIFF
--- a/src/main/java/com/example/projectlxp/course/controller/CourseController.java
+++ b/src/main/java/com/example/projectlxp/course/controller/CourseController.java
@@ -2,6 +2,7 @@ package com.example.projectlxp.course.controller;
 
 import jakarta.validation.Valid;
 
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -45,5 +46,11 @@ public class CourseController {
             @RequestBody CourseUpdateRequest request,
             @RequestParam Long userId) {
         return BaseResponse.success(courseService.updateCourse(courseId, request, userId));
+    }
+
+    @DeleteMapping("/{courseId}")
+    public BaseResponse<Boolean> deleteCourse(
+            @PathVariable Long courseId, @RequestParam Long userId) {
+        return BaseResponse.success("강좌 삭제 성공", courseService.deleteCourse(courseId, userId));
     }
 }

--- a/src/main/java/com/example/projectlxp/course/entity/Course.java
+++ b/src/main/java/com/example/projectlxp/course/entity/Course.java
@@ -64,8 +64,7 @@ public class Course extends BaseEntity {
     @Column(nullable = false)
     private CourseLevel level;
 
-    @Column(name = "is_deleted", nullable = false)
-    @ColumnDefault("false")
+    @Column(name = "is_deleted", nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
     private boolean isDeleted = false;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -84,28 +83,6 @@ public class Course extends BaseEntity {
 
     @OneToMany(mappedBy = "course")
     private List<Review> reviews = new ArrayList<>();
-
-    @Builder
-    public Course(
-            String title,
-            String summary,
-            String description,
-            int price,
-            String thumbnail,
-            CourseLevel level,
-            boolean isDeleted,
-            User instructor,
-            Category category) {
-        this.title = title;
-        this.summary = summary;
-        this.description = description;
-        this.price = price;
-        this.thumbnail = thumbnail;
-        this.level = level;
-        this.isDeleted = isDeleted;
-        this.instructor = instructor;
-        this.category = category;
-    }
 
     public void updateDetails(
             String title,

--- a/src/main/java/com/example/projectlxp/course/repository/CourseRepository.java
+++ b/src/main/java/com/example/projectlxp/course/repository/CourseRepository.java
@@ -31,4 +31,6 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
         WHERE c.id = :courseId
     """)
     Optional<Course> findByIdWithInstructorAndCategory(Long courseId);
+
+    Optional<Course> findByIdAndInstructorId(Long courseId, Long instructorId);
 }

--- a/src/main/java/com/example/projectlxp/course/service/CourseService.java
+++ b/src/main/java/com/example/projectlxp/course/service/CourseService.java
@@ -12,4 +12,6 @@ public interface CourseService {
     CourseResponse searchCourse(Long courseId);
 
     CourseDTO updateCourse(Long courseId, CourseUpdateRequest request, Long userId);
+
+    Boolean deleteCourse(Long courseId, Long userId);
 }

--- a/src/main/java/com/example/projectlxp/course/service/CourseServiceImpl.java
+++ b/src/main/java/com/example/projectlxp/course/service/CourseServiceImpl.java
@@ -85,4 +85,15 @@ public class CourseServiceImpl implements CourseService {
                 category);
         return CourseDTO.from(course);
     }
+
+    @Override
+    @Transactional
+    public Boolean deleteCourse(Long courseId, Long userId) {
+        Course course =
+                courseRepository
+                        .findByIdAndInstructorId(courseId, userId)
+                        .orElseThrow(CourseNotFoundException::new);
+        courseRepository.delete(course);
+        return true;
+    }
 }


### PR DESCRIPTION
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->

## ❗️ 이슈 번호
Closes #58 

## 📝 작업 내용

강좌 삭제 기능 구현하였습니다.
update문으로 나가는 것까지 확인했습니다.
```
Hibernate: 
    select
        c1_0.id,
        c1_0.category_id,
        c1_0.created_at,
        c1_0.description,
        c1_0.instructor_id,
        c1_0.is_deleted,
        c1_0.level,
        c1_0.modified_at,
        c1_0.price,
        c1_0.summary,
        c1_0.thumbnail,
        c1_0.title 
    from
        courses c1_0 
    left join
        users i1_0 
            on i1_0.id=c1_0.instructor_id 
            and (i1_0.is_deleted = 0) 
    where
        (
            c1_0.is_deleted = 0
        ) 
        and c1_0.id=? 
        and i1_0.id=?
Hibernate: 
    select
        s1_0.course_id,
        s1_0.id,
        s1_0.created_at,
        s1_0.is_deleted,
        s1_0.modified_at,
        s1_0.order_no,
        s1_0.title 
    from
        sections s1_0 
    where
        s1_0.course_id=? 
        and (
            s1_0.is_deleted = 0
        )
Hibernate: 
    UPDATE
        courses 
    SET
        is_deleted = true 
    WHERE
        id = ?
```

## 💭 주의 사항

## 💡 리뷰 포인트
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->
