### PR TITLE
[FEAT] 강의 수정 API 구현

### DIFF
--- a/src/main/java/com/example/projectlxp/lecture/controller/LectureController.java
+++ b/src/main/java/com/example/projectlxp/lecture/controller/LectureController.java
@@ -2,14 +2,20 @@ package com.example.projectlxp.lecture.controller;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.projectlxp.global.dto.BaseResponse;
+import com.example.projectlxp.lecture.controller.dto.LectureModifyDTO;
 import com.example.projectlxp.lecture.controller.dto.request.LectureCreateRequestDTO;
+import com.example.projectlxp.lecture.controller.dto.request.LectureUpdateRequestDTO;
 import com.example.projectlxp.lecture.controller.dto.response.LectureCreateResponseDTO;
+import com.example.projectlxp.lecture.controller.dto.response.LectureUpdateResponseDTO;
 import com.example.projectlxp.lecture.service.LectureService;
 
 @RestController
@@ -22,6 +28,7 @@ public class LectureController {
         this.lectureService = lectureService;
     }
 
+    // TODO : Service layer에 넘길 때, DTO로 넘기는 것이 더 직관적일 수 있다 !
     @PostMapping
     public BaseResponse<LectureCreateResponseDTO> createLecture(
             @ModelAttribute LectureCreateRequestDTO request,
@@ -34,6 +41,21 @@ public class LectureController {
                         request.title(),
                         request.orderNo(),
                         request.file());
+        return BaseResponse.success(response);
+    }
+
+    @PatchMapping("/{lectureId}")
+    public BaseResponse<LectureUpdateResponseDTO> updateLecture(
+            @PathVariable(name = "lectureId") Long lectureId,
+            @RequestBody LectureUpdateRequestDTO request,
+            @RequestParam(name = "userId", defaultValue = "1") Long userId) {
+
+        // convert to LectureModifyDTO
+        LectureModifyDTO modifyInfo =
+                new LectureModifyDTO(userId, lectureId, request.getTitle(), request.getOrderNo());
+
+        LectureUpdateResponseDTO response = lectureService.modifyLecture(modifyInfo);
+
         return BaseResponse.success(response);
     }
 }

--- a/src/main/java/com/example/projectlxp/lecture/controller/dto/LectureModifyDTO.java
+++ b/src/main/java/com/example/projectlxp/lecture/controller/dto/LectureModifyDTO.java
@@ -1,0 +1,19 @@
+package com.example.projectlxp.lecture.controller.dto;
+
+import lombok.Getter;
+
+@Getter
+public class LectureModifyDTO {
+
+    private Long userId;
+    private Long lectureId;
+    private String title;
+    private int orderNo;
+
+    public LectureModifyDTO(Long userId, Long lectureId, String title, int orderNo) {
+        this.userId = userId;
+        this.lectureId = lectureId;
+        this.orderNo = orderNo;
+        this.title = title;
+    }
+}

--- a/src/main/java/com/example/projectlxp/lecture/controller/dto/request/LectureUpdateRequestDTO.java
+++ b/src/main/java/com/example/projectlxp/lecture/controller/dto/request/LectureUpdateRequestDTO.java
@@ -1,0 +1,16 @@
+package com.example.projectlxp.lecture.controller.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class LectureUpdateRequestDTO {
+
+    private String title;
+
+    private int orderNo;
+
+    public LectureUpdateRequestDTO(String title, int orderNo) {
+        this.title = title;
+        this.orderNo = orderNo;
+    }
+}

--- a/src/main/java/com/example/projectlxp/lecture/controller/dto/response/LectureUpdateResponseDTO.java
+++ b/src/main/java/com/example/projectlxp/lecture/controller/dto/response/LectureUpdateResponseDTO.java
@@ -1,0 +1,19 @@
+package com.example.projectlxp.lecture.controller.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class LectureUpdateResponseDTO {
+
+    private Long lectureId;
+
+    private String title;
+
+    private int orderNo;
+
+    public LectureUpdateResponseDTO(Long lectureId, String title, int orderNo) {
+        this.lectureId = lectureId;
+        this.title = title;
+        this.orderNo = orderNo;
+    }
+}

--- a/src/main/java/com/example/projectlxp/lecture/entity/Lecture.java
+++ b/src/main/java/com/example/projectlxp/lecture/entity/Lecture.java
@@ -91,4 +91,11 @@ public class Lecture extends BaseEntity {
             String duration) {
         return new Lecture(title, type, orderNo, fileURL, section, duration);
     }
+
+    public Lecture updateLecture(String title, int orderNo) {
+        this.title = title != null ? title : this.title;
+        this.orderNo = orderNo != 0 ? orderNo : this.orderNo;
+
+        return this;
+    }
 }

--- a/src/main/java/com/example/projectlxp/lecture/repository/LectureRepository.java
+++ b/src/main/java/com/example/projectlxp/lecture/repository/LectureRepository.java
@@ -3,6 +3,7 @@ package com.example.projectlxp.lecture.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.example.projectlxp.lecture.entity.Lecture;
@@ -13,4 +14,28 @@ public interface LectureRepository extends JpaRepository<Lecture, Long> {
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE Lecture l SET l.isDeleted = true WHERE l.section.id = :sectionId")
     void deleteBySectionId(Long sectionId);
+
+    /** orderNo를 올릴 때 사용합니다. */
+    @Modifying
+    @Query(
+            "UPDATE Lecture l SET l.orderNo = l.orderNo + 1 "
+                    + "WHERE l.section.id = :sectionId "
+                    + "AND l.orderNo >= :newOrderNo "
+                    + "AND l.orderNo < :oldOrderNo")
+    void incrementOrderBetween(
+            @Param("sectionId") Long sectionId,
+            @Param("oldOrderNo") int oldOrderNo,
+            @Param("newOrderNo") int newOrderNo);
+
+    /** orderNo를 내릴 때 사용합니다. */
+    @Modifying
+    @Query(
+            "UPDATE Lecture l SET l.orderNo = l.orderNo - 1 "
+                    + "WHERE l.section.id = :sectionId "
+                    + "AND l.orderNo > :oldOrderNo "
+                    + "AND l.orderNo <= :newOrderNo")
+    void decrementOrderBetween(
+            @Param("sectionId") Long sectionId,
+            @Param("oldOrderNo") int oldOrderNo,
+            @Param("newOrderNo") int newOrderNo);
 }

--- a/src/main/java/com/example/projectlxp/lecture/service/LectureService.java
+++ b/src/main/java/com/example/projectlxp/lecture/service/LectureService.java
@@ -2,7 +2,9 @@ package com.example.projectlxp.lecture.service;
 
 import org.springframework.web.multipart.MultipartFile;
 
+import com.example.projectlxp.lecture.controller.dto.LectureModifyDTO;
 import com.example.projectlxp.lecture.controller.dto.response.LectureCreateResponseDTO;
+import com.example.projectlxp.lecture.controller.dto.response.LectureUpdateResponseDTO;
 
 public interface LectureService {
 
@@ -16,7 +18,15 @@ public interface LectureService {
      * @param file 업로드하는 파일
      * @return LectureCreateResponseDTO
      */
-    public LectureCreateResponseDTO registerLecture(
+    LectureCreateResponseDTO registerLecture(
             Long userId, Long sectionId, String title, int orderNo, MultipartFile file)
             throws Exception;
+
+    /**
+     * 강의의 제목, 순서, 섹션을 수정합니다.
+     *
+     * @param modifyInfo 변경하고자 하는 정보들
+     * @return LectureUpdateResponseDTO
+     */
+    LectureUpdateResponseDTO modifyLecture(LectureModifyDTO modifyInfo);
 }

--- a/src/main/java/com/example/projectlxp/lecture/service/validator/LectureValidator.java
+++ b/src/main/java/com/example/projectlxp/lecture/service/validator/LectureValidator.java
@@ -4,6 +4,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
 import com.example.projectlxp.global.error.CustomBusinessException;
+import com.example.projectlxp.lecture.controller.dto.LectureModifyDTO;
 
 @Component
 public class LectureValidator {
@@ -11,6 +12,20 @@ public class LectureValidator {
     public void validateLectureAuthority(Long authId, Long checkId) {
         if (!authId.equals(checkId)) {
             throw new CustomBusinessException("강의를 관리할 권한이 없습니다.", HttpStatus.FORBIDDEN);
+        }
+    }
+
+    public void validateLectureModifyInfo(LectureModifyDTO dto) {
+        if ((dto.getTitle() == null || dto.getTitle().isBlank()) && dto.getOrderNo() == 0) {
+            throw new CustomBusinessException("수정할 필드가 없습니다.", HttpStatus.BAD_REQUEST);
+        }
+
+        if (dto.getTitle() != null && dto.getTitle().isBlank()) {
+            throw new CustomBusinessException("강의 제목은 비워둘 수 없습니다.", HttpStatus.BAD_REQUEST);
+        }
+
+        if (dto.getOrderNo() != 0 && dto.getOrderNo() <= 0) {
+            throw new CustomBusinessException("강의 순서는 1 이상의 값이어야 합니다.", HttpStatus.BAD_REQUEST);
         }
     }
 }


### PR DESCRIPTION
## ❗️ 이슈 번호
#65 

## 📝 작업 내용
1. Lecture Controller을 아래와 같은 순서로 구현하였습니다.
- 컨트롤러에서 서비스로 넘기는 DTO 검증로직 수행
- Lecture 존재 여부 검증
- Lecture 권한 검증
- 동일한 Section에 존재하는 oldOrderNo - newOrderNO로 orderNo를 재정렬
- Lecture업데이트 더티체킹
- ResponseDTO로 변환 후 return
2. Request, Response, Modify DTO를 추가하였습니다.
3. JPQL을 이용하여 OrderNo를 재정렬하는 메서드를 추가하였습니다.
4. LectureValidator에 DTO를 검증하는 로직을 추가하였습니다.

## 💭 주의 사항
- Patch 메서드로 받아오니 `Validation`라이브러리로 인한 검증이 불가능하여 LectureValidator에서 검증을 진행하였습니다. 

## 💡 리뷰 포인트
1. 리팩토링 할 부분이 보이면 알려주세요
2. DTO 검증 부분이 DTO 내부가 좋을지 Validator가 좋을지 모르겠습니다
3. DTO를 record 대신 필드를 private으로 만들었는데, 어떤 게 더 좋은지 모르겠습니다 
