### PR TITLE
[FEAT] 강의 삭제 API 구현

### DIFF
--- a/src/main/java/com/example/projectlxp/lecture/controller/LectureController.java
+++ b/src/main/java/com/example/projectlxp/lecture/controller/LectureController.java
@@ -1,6 +1,7 @@
 package com.example.projectlxp.lecture.controller;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.projectlxp.global.dto.BaseResponse;
+import com.example.projectlxp.lecture.controller.dto.LectureDeleteDTO;
 import com.example.projectlxp.lecture.controller.dto.LectureModifyDTO;
 import com.example.projectlxp.lecture.controller.dto.request.LectureCreateRequestDTO;
 import com.example.projectlxp.lecture.controller.dto.request.LectureUpdateRequestDTO;
@@ -57,5 +59,15 @@ public class LectureController {
         LectureUpdateResponseDTO response = lectureService.modifyLecture(modifyInfo);
 
         return BaseResponse.success(response);
+    }
+
+    @DeleteMapping("/{lectureId}")
+    public BaseResponse<?> deleteLecture(
+            @PathVariable(name = "lectureId") Long lectureId,
+            @RequestParam(name = "userId", defaultValue = "1") Long userId) {
+        // convert to DTO
+        LectureDeleteDTO deleteInfo = new LectureDeleteDTO(userId, lectureId);
+        lectureService.removeLecture(deleteInfo);
+        return BaseResponse.success("Deleted Lecture");
     }
 }

--- a/src/main/java/com/example/projectlxp/lecture/controller/dto/LectureDeleteDTO.java
+++ b/src/main/java/com/example/projectlxp/lecture/controller/dto/LectureDeleteDTO.java
@@ -1,0 +1,15 @@
+package com.example.projectlxp.lecture.controller.dto;
+
+import lombok.Getter;
+
+@Getter
+public class LectureDeleteDTO {
+
+    private Long userId;
+    private Long lectureId;
+
+    public LectureDeleteDTO(Long userId, Long lectureId) {
+        this.userId = userId;
+        this.lectureId = lectureId;
+    }
+}

--- a/src/main/java/com/example/projectlxp/lecture/repository/LectureRepository.java
+++ b/src/main/java/com/example/projectlxp/lecture/repository/LectureRepository.java
@@ -38,4 +38,11 @@ public interface LectureRepository extends JpaRepository<Lecture, Long> {
             @Param("sectionId") Long sectionId,
             @Param("oldOrderNo") int oldOrderNo,
             @Param("newOrderNo") int newOrderNo);
+
+    @Modifying
+    @Query(
+            "UPDATE Lecture l SET l.orderNo = l.orderNo - 1"
+                    + " WHERE l.section.id = :sectionId AND l.orderNo > :orderNo")
+    void decrementOrderAfterDelete(
+            @Param("sectionId") Long sectionId, @Param("orderNo") int deletedOrderNo);
 }

--- a/src/main/java/com/example/projectlxp/lecture/service/LectureService.java
+++ b/src/main/java/com/example/projectlxp/lecture/service/LectureService.java
@@ -2,6 +2,7 @@ package com.example.projectlxp.lecture.service;
 
 import org.springframework.web.multipart.MultipartFile;
 
+import com.example.projectlxp.lecture.controller.dto.LectureDeleteDTO;
 import com.example.projectlxp.lecture.controller.dto.LectureModifyDTO;
 import com.example.projectlxp.lecture.controller.dto.response.LectureCreateResponseDTO;
 import com.example.projectlxp.lecture.controller.dto.response.LectureUpdateResponseDTO;
@@ -29,4 +30,11 @@ public interface LectureService {
      * @return LectureUpdateResponseDTO
      */
     LectureUpdateResponseDTO modifyLecture(LectureModifyDTO modifyInfo);
+
+    /**
+     * 강의를 삭제합니다.
+     *
+     * @param deleteInfo 강의 삭제 시 필요한 정보들
+     */
+    void removeLecture(LectureDeleteDTO deleteInfo);
 }

--- a/src/main/java/com/example/projectlxp/lecture/service/impl/LectureServiceImpl.java
+++ b/src/main/java/com/example/projectlxp/lecture/service/impl/LectureServiceImpl.java
@@ -9,6 +9,7 @@ import org.springframework.web.multipart.MultipartFile;
 import com.example.projectlxp.content.service.ContentService;
 import com.example.projectlxp.content.service.dto.UploadFileInfoDTO;
 import com.example.projectlxp.global.error.CustomBusinessException;
+import com.example.projectlxp.lecture.controller.dto.LectureDeleteDTO;
 import com.example.projectlxp.lecture.controller.dto.LectureModifyDTO;
 import com.example.projectlxp.lecture.controller.dto.response.LectureCreateResponseDTO;
 import com.example.projectlxp.lecture.controller.dto.response.LectureUpdateResponseDTO;
@@ -116,6 +117,28 @@ public class LectureServiceImpl implements LectureService {
                 updatedLecture.getSection().getId(),
                 updatedLecture.getTitle(),
                 updatedLecture.getOrderNo());
+    }
+
+    @Override
+    @Transactional
+    public void removeLecture(LectureDeleteDTO deleteInfo) {
+        // set info
+        Long userId = deleteInfo.getUserId();
+        Long lectureId = deleteInfo.getLectureId();
+
+        // find Lecture
+        Lecture findLecture = findLectureAndException(lectureId);
+
+        // validate lecture authority
+        lectureValidator.validateLectureAuthority(
+                findLecture.getSection().getCourse().getInstructor().getId(), userId);
+
+        // soft delete lecture
+        lectureRepository.delete(findLecture);
+
+        // order_no reorder
+        lectureRepository.decrementOrderAfterDelete(
+                findLecture.getSection().getId(), findLecture.getOrderNo());
     }
 
     private Lecture findLectureAndException(Long lectureId) {


### PR DESCRIPTION
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->

## ❗️ 이슈 번호
#69 

## 📝 작업 내용
1. LectureDeleteDTO를 추가하였습니다.
2. 강의 삭제 기능을 추가하였습니다.
- Controller : 필요한 정보들을 DTO로 감싸서 Service에 보냅니다.
- Service : Lecture 존재 여부 확인, 관리 권한 확인 후 soft delete, Section내 lecture들의 orderNo 재정렬 순으로 로직을 구현하였습니다.
- Repository : Section을 기준으로 Lecture의 orderNo를 재정렬하는 쿼리문을 작성하였습니다.

 
<img width="506" height="122" alt="image" src="https://github.com/user-attachments/assets/6c5a3db4-6db2-4ee0-9326-6f71db65f32b" />
- 삭제 시, is_deleted =1, orderNo는 재정렬 된 것을 확인했습니다.



## 💭 주의 사항

## 💡 리뷰 포인트
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->
