### PR TITLE
[FEAT] 회원정보조회 및 회원정보수정 

### DIFF
--- a/src/main/java/com/example/projectlxp/global/annotation/CurrentUserId.java
+++ b/src/main/java/com/example/projectlxp/global/annotation/CurrentUserId.java
@@ -1,4 +1,4 @@
-package com.example.projectlxp.global.config;
+package com.example.projectlxp.global.annotation;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;

--- a/src/main/java/com/example/projectlxp/global/config/CurrentUserArgumentResolver.java
+++ b/src/main/java/com/example/projectlxp/global/config/CurrentUserArgumentResolver.java
@@ -9,6 +9,8 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
+import com.example.projectlxp.global.annotation.CurrentUserId;
+
 @Component
 public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolver {
 

--- a/src/main/java/com/example/projectlxp/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/projectlxp/global/config/SecurityConfig.java
@@ -78,7 +78,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(
                         authorize ->
                                 authorize
-                                        .requestMatchers("/join", "/login")
+                                        .requestMatchers("/join", "/login", "/logout")
                                         .permitAll() // 회원가입 로그인은 누구나
                                         .requestMatchers("/me", "/update")
                                         .authenticated() // 정보조회,수정은 인증필요

--- a/src/main/java/com/example/projectlxp/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/projectlxp/global/jwt/JwtAuthenticationFilter.java
@@ -32,12 +32,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         String token = resolveToken(request);
         if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
-
             Authentication authentication = jwtTokenProvider.getAuthentication(token);
-
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
-
         filterChain.doFilter(request, response);
     }
 

--- a/src/main/java/com/example/projectlxp/user/controller/UserController.java
+++ b/src/main/java/com/example/projectlxp/user/controller/UserController.java
@@ -2,13 +2,19 @@ package com.example.projectlxp.user.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.example.projectlxp.global.annotation.CurrentUserId;
 import com.example.projectlxp.user.dto.TokenResponseDTO;
 import com.example.projectlxp.user.dto.UserJoinRequestDTO;
 import com.example.projectlxp.user.dto.UserLoginRequestDTO;
+import com.example.projectlxp.user.dto.UserPasswordUpdateRequestDTO;
+import com.example.projectlxp.user.dto.UserResponseDTO;
+import com.example.projectlxp.user.dto.UserUpdateRequestDTO;
 import com.example.projectlxp.user.service.UserService;
 
 import lombok.RequiredArgsConstructor;
@@ -37,5 +43,37 @@ public class UserController {
 
         TokenResponseDTO tokenDTO = userService.login(requestDTO);
         return ResponseEntity.ok(tokenDTO);
+    }
+
+    // 로그아웃은 Security에 의해서 자동으로 API 매핑 됩니다.
+    // 로그인 = Manual , 로그아웃 = Automatic
+
+    // 정보조회 API
+    @GetMapping("/me")
+    public ResponseEntity<Object> getMyInfo(@CurrentUserId Long userId) {
+
+        UserResponseDTO responseDTO = userService.getMyInfo(userId);
+        return ResponseEntity.ok(responseDTO);
+    }
+
+    // 정보수정 API Put = 전체수정 , Path = 부분수정 방식은 비슷함
+    @PatchMapping("/update")
+    public ResponseEntity<UserResponseDTO> updateMyInfo(
+            @CurrentUserId Long userId, // 누가 수정할지 (토큰으로 식별)
+            @Validated @RequestBody UserUpdateRequestDTO requestDTO // 무엇을 수정할지
+            ) {
+        UserResponseDTO responseDTO = userService.updateMyInfo(userId, requestDTO);
+
+        return ResponseEntity.ok(responseDTO);
+    }
+
+    @PatchMapping("/update-password")
+    public ResponseEntity<String> updatePassword(
+            @CurrentUserId Long userId,
+            @Validated @RequestBody UserPasswordUpdateRequestDTO requestDTO) {
+
+        userService.updatePassword(userId, requestDTO);
+
+        return ResponseEntity.ok("비밀번호가 성공적으로 변경되었습니다. ");
     }
 }

--- a/src/main/java/com/example/projectlxp/user/dto/TokenResponseDTO.java
+++ b/src/main/java/com/example/projectlxp/user/dto/TokenResponseDTO.java
@@ -9,8 +9,9 @@ public class TokenResponseDTO {
     private String refreshtoken;
     private String tokenType = "Bearer"; // 출입증
 
-    public TokenResponseDTO(String accesstoken, String refreshtoken) {
+    public TokenResponseDTO(String accesstoken, String refreshtoken, String tokenType) {
         this.accesstoken = accesstoken;
         this.refreshtoken = refreshtoken;
+        this.tokenType = "Bearer";
     }
 }

--- a/src/main/java/com/example/projectlxp/user/dto/UserPasswordUpdateRequestDTO.java
+++ b/src/main/java/com/example/projectlxp/user/dto/UserPasswordUpdateRequestDTO.java
@@ -1,0 +1,24 @@
+package com.example.projectlxp.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UserPasswordUpdateRequestDTO {
+
+    @NotBlank(message = "현재 비밀번호를 입력해주세요. ")
+    private String currentPassword;
+
+    @NotBlank(message = "새 비밀번호를 입력해주세요. ")
+    @Pattern(
+            regexp = "^(?=.*[a-z])(?=.*\\d)[a-z\\d]{6,}$",
+            message = "비밀번호는 6자 이상이며, 영문 소문자와 숫자를 각각 1개 이상 포함해야 합니다.")
+    private String newPassword;
+
+    @NotBlank(message = "새 비밀번호를 다시 한번 입력해주세요")
+    private String confirmNewPassword;
+}

--- a/src/main/java/com/example/projectlxp/user/dto/UserResponseDTO.java
+++ b/src/main/java/com/example/projectlxp/user/dto/UserResponseDTO.java
@@ -1,0 +1,28 @@
+package com.example.projectlxp.user.dto;
+
+import com.example.projectlxp.user.entity.Role;
+import com.example.projectlxp.user.entity.User;
+
+import lombok.Getter;
+
+@Getter
+
+/*
+ *  공용 응답 DTO로
+ * */
+public class UserResponseDTO {
+
+    private Long userId;
+    private String email;
+    private String name;
+    private Role role;
+    private String profileImage;
+
+    public UserResponseDTO(User user) {
+        this.userId = user.getId();
+        this.email = user.getEmail();
+        this.name = user.getName();
+        this.role = user.getRole();
+        this.profileImage = user.getProfileImage();
+    }
+}

--- a/src/main/java/com/example/projectlxp/user/entity/User.java
+++ b/src/main/java/com/example/projectlxp/user/entity/User.java
@@ -86,8 +86,14 @@ public class User extends BaseEntity {
         this.name = name;
     }
 
-    public void updateProfileImage(String profileImage) {
-        this.profileImage = profileImage;
+    public void updateInfo(String name, String profileImage) {
+
+        if (name != null) {
+            this.name = name;
+        }
+        if (profileImage != null) {
+            this.profileImage = profileImage;
+        }
     }
 
     public void updatePassword(String hashedPassword) {

--- a/src/main/java/com/example/projectlxp/user/entity/User.java
+++ b/src/main/java/com/example/projectlxp/user/entity/User.java
@@ -81,4 +81,16 @@ public class User extends BaseEntity {
             String name, String email, String hashedPassword, Role role, String profileImage) {
         return new User(name, role, email, hashedPassword, profileImage);
     }
+
+    public void updateName(String name) {
+        this.name = name;
+    }
+
+    public void updateProfileImage(String profileImage) {
+        this.profileImage = profileImage;
+    }
+
+    public void updatePassword(String hashedPassword) {
+        this.hashedPassword = hashedPassword;
+    }
 }

--- a/src/main/java/com/example/projectlxp/user/service/CustomUserDetailService.java
+++ b/src/main/java/com/example/projectlxp/user/service/CustomUserDetailService.java
@@ -33,7 +33,7 @@ public class CustomUserDetailService implements UserDetailsService {
                         .orElseThrow(
                                 () ->
                                         new UsernameNotFoundException(
-                                                "User not found with username: " + email));
+                                                "인증된 이메일을 찾을 수 없습니다. email : " + email));
 
         return new CustomUserDetails(
                 user.getId(),

--- a/src/main/java/com/example/projectlxp/user/service/UserService.java
+++ b/src/main/java/com/example/projectlxp/user/service/UserService.java
@@ -3,21 +3,24 @@ package com.example.projectlxp.user.service;
 import com.example.projectlxp.user.dto.TokenResponseDTO;
 import com.example.projectlxp.user.dto.UserJoinRequestDTO;
 import com.example.projectlxp.user.dto.UserLoginRequestDTO;
+import com.example.projectlxp.user.dto.UserPasswordUpdateRequestDTO;
+import com.example.projectlxp.user.dto.UserResponseDTO;
+import com.example.projectlxp.user.dto.UserUpdateRequestDTO;
 
 public interface UserService {
 
-    /*
-     * 회원가입 비즈니스 로직
-     * @Param requestDTO 회원가입 요청 정보
-     * */
-
+    // 가입
     void join(UserJoinRequestDTO requestDTO);
 
     // 로그인
-
     TokenResponseDTO login(UserLoginRequestDTO requestDTO);
 
     // 정보 조회
+    UserResponseDTO getMyInfo(Long userId);
 
-    // 정보수정
+    // 정보수정 (이름, 프로필이미지_
+    UserResponseDTO updateMyInfo(Long userId, UserUpdateRequestDTO requestDTO);
+
+    // 정보수정 (패스워드)
+    void updatePassword(Long userId, UserPasswordUpdateRequestDTO requestDTO);
 }

--- a/src/main/java/com/example/projectlxp/user/service/UserServiceImpl.java
+++ b/src/main/java/com/example/projectlxp/user/service/UserServiceImpl.java
@@ -62,8 +62,13 @@ public class UserServiceImpl implements UserService {
 
     // 회원 정보조회
     @Override
-    @Transactional(readOnly = true)
     public UserResponseDTO getMyInfo(Long userId) {
+
+        User user = getUser(userId);
+        return new UserResponseDTO(user);
+    }
+
+    private User getUser(Long userId) {
         User user =
                 userRepository
                         .findById(userId)
@@ -71,28 +76,16 @@ public class UserServiceImpl implements UserService {
                                 () ->
                                         new UsernameNotFoundException(
                                                 "인증된 사용자를 찾을 수 없습니다. ID: " + userId));
-        return new UserResponseDTO(user);
+        return user;
     }
 
     // 회원 정보수정
     @Override
     @Transactional
     public UserResponseDTO updateMyInfo(Long userId, UserUpdateRequestDTO requestDTO) {
-        User user =
-                userRepository
-                        .findById(userId)
-                        .orElseThrow(
-                                () ->
-                                        new UsernameNotFoundException(
-                                                "수정할 사용자를 찾을 수 없습니다. ID" + userId));
+        User user = getUser(userId);
 
-        if (requestDTO.getName() != null) {
-            user.updateName(requestDTO.getName());
-        }
-        if (requestDTO.getProfileImage() != null) {
-            user.updateProfileImage(requestDTO.getProfileImage());
-        }
-
+        user.updateInfo(requestDTO.getName(), requestDTO.getProfileImage());
         return new UserResponseDTO(user);
     }
 

--- a/src/main/java/com/example/projectlxp/user/service/UserServiceImpl.java
+++ b/src/main/java/com/example/projectlxp/user/service/UserServiceImpl.java
@@ -3,7 +3,7 @@ package com.example.projectlxp.user.service;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,6 +12,9 @@ import com.example.projectlxp.global.jwt.JwtTokenProvider;
 import com.example.projectlxp.user.dto.TokenResponseDTO;
 import com.example.projectlxp.user.dto.UserJoinRequestDTO;
 import com.example.projectlxp.user.dto.UserLoginRequestDTO;
+import com.example.projectlxp.user.dto.UserPasswordUpdateRequestDTO;
+import com.example.projectlxp.user.dto.UserResponseDTO;
+import com.example.projectlxp.user.dto.UserUpdateRequestDTO;
 import com.example.projectlxp.user.entity.User;
 import com.example.projectlxp.user.repository.UserRepository;
 
@@ -50,12 +53,67 @@ public class UserServiceImpl implements UserService {
         // AuthenticationManager로 인증 (loadUserByUsername 호출 및 비번 비교
         Authentication authentication = authenticationManager.authenticate(authenticationToken);
 
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-
         String accessToken = jwtTokenProvider.createAccessToken(authentication); // 액세스 토큰 발급
         String refreshToken = jwtTokenProvider.createRefreshToken(authentication); // 리프레쉬 토큰 발급
 
         // 인증 성공 시 DTO에 두 토큰 생성
-        return new TokenResponseDTO(accessToken, refreshToken);
+        return new TokenResponseDTO(accessToken, refreshToken, "Bearer");
+    }
+
+    // 회원 정보조회
+    @Override
+    @Transactional(readOnly = true)
+    public UserResponseDTO getMyInfo(Long userId) {
+        User user =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(
+                                () ->
+                                        new UsernameNotFoundException(
+                                                "인증된 사용자를 찾을 수 없습니다. ID: " + userId));
+        return new UserResponseDTO(user);
+    }
+
+    // 회원 정보수정
+    @Override
+    @Transactional
+    public UserResponseDTO updateMyInfo(Long userId, UserUpdateRequestDTO requestDTO) {
+        User user =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(
+                                () ->
+                                        new UsernameNotFoundException(
+                                                "수정할 사용자를 찾을 수 없습니다. ID" + userId));
+
+        if (requestDTO.getName() != null) {
+            user.updateName(requestDTO.getName());
+        }
+        if (requestDTO.getProfileImage() != null) {
+            user.updateProfileImage(requestDTO.getProfileImage());
+        }
+
+        return new UserResponseDTO(user);
+    }
+
+    @Override
+    @Transactional
+    public void updatePassword(Long userId, UserPasswordUpdateRequestDTO requestDTO) {
+
+        if (!requestDTO.getNewPassword().equals(requestDTO.getConfirmNewPassword())) {
+            throw new IllegalStateException("변경할 비밀번호와 서로 일치하지 않습니다.");
+        }
+
+        User user =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(
+                                () ->
+                                        new UsernameNotFoundException(
+                                                "인증된 사용자를 찾을 수 없습니다 ID " + userId));
+        if (!passwordEncoder.matches(requestDTO.getCurrentPassword(), user.getHashedPassword())) {
+            throw new IllegalArgumentException("현재 비밀번호가 일치하지 않습니다.");
+        }
+        user.updatePassword(passwordEncoder.encode(requestDTO.getNewPassword()));
     }
 }


### PR DESCRIPTION
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->

## ❗️ 이슈 번호
#74 

## 📝 작업 내용
- 회원정보 조회 및 회원정보수정 API

## 💭 주의 사항
- 정보를 수정할 때 name,profileimage 와 패스워드는 각각 변경할 수 있습니다.
- 정보를 수정할 때 access토큰을 필요로 합니다. 
-  이 토큰은 헤더에 Authorization의 Bearer의 타입으로 넣어줘야합니다. 

## 💡 리뷰 포인트
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->
