### PR TITLE
[FEAT] 강의 단일 조회 API 구현

### DIFF
--- a/src/main/java/com/example/projectlxp/lecture/controller/LectureController.java
+++ b/src/main/java/com/example/projectlxp/lecture/controller/LectureController.java
@@ -2,6 +2,7 @@ package com.example.projectlxp.lecture.controller;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -13,10 +14,12 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.example.projectlxp.global.dto.BaseResponse;
 import com.example.projectlxp.lecture.controller.dto.LectureDeleteDTO;
+import com.example.projectlxp.lecture.controller.dto.LectureDetailDTO;
 import com.example.projectlxp.lecture.controller.dto.LectureModifyDTO;
 import com.example.projectlxp.lecture.controller.dto.request.LectureCreateRequestDTO;
 import com.example.projectlxp.lecture.controller.dto.request.LectureUpdateRequestDTO;
 import com.example.projectlxp.lecture.controller.dto.response.LectureCreateResponseDTO;
+import com.example.projectlxp.lecture.controller.dto.response.LectureGetDetailResponseDTO;
 import com.example.projectlxp.lecture.controller.dto.response.LectureUpdateResponseDTO;
 import com.example.projectlxp.lecture.service.LectureService;
 
@@ -69,5 +72,16 @@ public class LectureController {
         LectureDeleteDTO deleteInfo = new LectureDeleteDTO(userId, lectureId);
         lectureService.removeLecture(deleteInfo);
         return BaseResponse.success("Deleted Lecture");
+    }
+
+    @GetMapping("/{lectureId}")
+    public BaseResponse<LectureGetDetailResponseDTO> getLecture(
+            @PathVariable(name = "lectureId") Long lectureId,
+            @RequestParam(name = "userId", defaultValue = "1") Long userId) {
+
+        LectureDetailDTO lectureInfo = new LectureDetailDTO(userId, lectureId);
+
+        LectureGetDetailResponseDTO response = lectureService.getLectureDetail(lectureInfo);
+        return BaseResponse.success(response);
     }
 }

--- a/src/main/java/com/example/projectlxp/lecture/controller/dto/LectureDetailDTO.java
+++ b/src/main/java/com/example/projectlxp/lecture/controller/dto/LectureDetailDTO.java
@@ -1,0 +1,3 @@
+package com.example.projectlxp.lecture.controller.dto;
+
+public record LectureDetailDTO(Long userId, Long lectureId) {}

--- a/src/main/java/com/example/projectlxp/lecture/controller/dto/response/LectureGetDetailResponseDTO.java
+++ b/src/main/java/com/example/projectlxp/lecture/controller/dto/response/LectureGetDetailResponseDTO.java
@@ -1,0 +1,6 @@
+package com.example.projectlxp.lecture.controller.dto.response;
+
+import com.example.projectlxp.lecture.entity.LectureType;
+
+public record LectureGetDetailResponseDTO(
+        Long lectureId, String title, String filePath, LectureType lectureType, int orderNo) {}

--- a/src/main/java/com/example/projectlxp/lecture/repository/LectureRepository.java
+++ b/src/main/java/com/example/projectlxp/lecture/repository/LectureRepository.java
@@ -1,6 +1,7 @@
 package com.example.projectlxp.lecture.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -55,4 +56,12 @@ public interface LectureRepository extends JpaRepository<Lecture, Long> {
                     + " WHERE l.section.id = :sectionId AND l.orderNo > :orderNo")
     void decrementOrderAfterDelete(
             @Param("sectionId") Long sectionId, @Param("orderNo") int deletedOrderNo);
+
+    @Query(
+            "SELECT l FROM Lecture l "
+                    + "JOIN FETCH l.section s "
+                    + "JOIN FETCH s.course c "
+                    + "JOIN FETCH c.instructor i"
+                    + " WHERE l.id = :id")
+    Optional<Lecture> findDetailById(Long id);
 }

--- a/src/main/java/com/example/projectlxp/lecture/service/LectureService.java
+++ b/src/main/java/com/example/projectlxp/lecture/service/LectureService.java
@@ -3,8 +3,10 @@ package com.example.projectlxp.lecture.service;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.example.projectlxp.lecture.controller.dto.LectureDeleteDTO;
+import com.example.projectlxp.lecture.controller.dto.LectureDetailDTO;
 import com.example.projectlxp.lecture.controller.dto.LectureModifyDTO;
 import com.example.projectlxp.lecture.controller.dto.response.LectureCreateResponseDTO;
+import com.example.projectlxp.lecture.controller.dto.response.LectureGetDetailResponseDTO;
 import com.example.projectlxp.lecture.controller.dto.response.LectureUpdateResponseDTO;
 
 public interface LectureService {
@@ -37,4 +39,11 @@ public interface LectureService {
      * @param deleteInfo 강의 삭제 시 필요한 정보들
      */
     void removeLecture(LectureDeleteDTO deleteInfo);
+
+    /**
+     * 강의의 디테일 정보를 조회합니다.
+     *
+     * @param detailInfo 강의의 세부 정보를 조회하기 위한 정보
+     */
+    LectureGetDetailResponseDTO getLectureDetail(LectureDetailDTO detailInfo);
 }

--- a/src/main/java/com/example/projectlxp/lecture/service/impl/LectureServiceImpl.java
+++ b/src/main/java/com/example/projectlxp/lecture/service/impl/LectureServiceImpl.java
@@ -10,8 +10,10 @@ import com.example.projectlxp.content.service.ContentService;
 import com.example.projectlxp.content.service.dto.UploadFileInfoDTO;
 import com.example.projectlxp.global.error.CustomBusinessException;
 import com.example.projectlxp.lecture.controller.dto.LectureDeleteDTO;
+import com.example.projectlxp.lecture.controller.dto.LectureDetailDTO;
 import com.example.projectlxp.lecture.controller.dto.LectureModifyDTO;
 import com.example.projectlxp.lecture.controller.dto.response.LectureCreateResponseDTO;
+import com.example.projectlxp.lecture.controller.dto.response.LectureGetDetailResponseDTO;
 import com.example.projectlxp.lecture.controller.dto.response.LectureUpdateResponseDTO;
 import com.example.projectlxp.lecture.entity.Lecture;
 import com.example.projectlxp.lecture.repository.LectureRepository;
@@ -139,6 +141,29 @@ public class LectureServiceImpl implements LectureService {
         // order_no reorder
         lectureRepository.decrementOrderAfterDelete(
                 findLecture.getSection().getId(), findLecture.getOrderNo());
+    }
+
+    @Override
+    @Transactional
+    public LectureGetDetailResponseDTO getLectureDetail(LectureDetailDTO detailInfo) {
+        // set info
+        Long userId = detailInfo.userId();
+        Long lectureId = detailInfo.lectureId();
+
+        // find Lecture
+        Lecture findLecture = findLectureAndException(lectureId);
+
+        // validate lecture authority
+        lectureValidator.validateLectureAuthority(
+                findLecture.getSection().getCourse().getInstructor().getId(), userId);
+
+        // convertDTO and return
+        return new LectureGetDetailResponseDTO(
+                lectureId,
+                findLecture.getTitle(),
+                findLecture.getFile(),
+                findLecture.getType(),
+                findLecture.getOrderNo());
     }
 
     private Lecture findLectureAndException(Long lectureId) {

--- a/src/main/java/com/example/projectlxp/lecture/service/impl/LectureServiceImpl.java
+++ b/src/main/java/com/example/projectlxp/lecture/service/impl/LectureServiceImpl.java
@@ -151,7 +151,7 @@ public class LectureServiceImpl implements LectureService {
         Long lectureId = detailInfo.lectureId();
 
         // find Lecture
-        Lecture findLecture = findLectureAndException(lectureId);
+        Lecture findLecture = findLectureDetail(lectureId);
 
         // validate lecture authority
         lectureValidator.validateLectureAuthority(
@@ -169,6 +169,13 @@ public class LectureServiceImpl implements LectureService {
     private Lecture findLectureAndException(Long lectureId) {
         return lectureRepository
                 .findById(lectureId)
+                .orElseThrow(
+                        () -> new CustomBusinessException("강의를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+    }
+
+    private Lecture findLectureDetail(Long lectureId) {
+        return lectureRepository
+                .findDetailById(lectureId)
                 .orElseThrow(
                         () -> new CustomBusinessException("강의를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
     }


### PR DESCRIPTION
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->

## ❗️ 이슈 번호
#75 

## 📝 작업 내용
1. 단일 Lecture의 정보를 반환합니다.
2. filePath를 반환 정보에 추가합니다.

```json
{
    "status": 200,
    "message": "OK",
    "data": {
        "lectureId": 1,
        "title": "스프링 프레임워크란?",
        "filePath": "intro.mp4",
        "lectureType": "VIDEO",
        "orderNo": 1
    },
    "code": "OK"
}
```

## 💭 주의 사항

## 💡 리뷰 포인트
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->
