### PR TITLE
[Refactor] ReviewController 임시 ID를 @AuthenticationPrincipal로 변경

### DIFF
--- a/src/main/java/com/example/projectlxp/review/controller/ReviewController.java
+++ b/src/main/java/com/example/projectlxp/review/controller/ReviewController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import jakarta.validation.Valid;
 
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -12,7 +13,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.projectlxp.global.dto.BaseResponse;
@@ -20,6 +20,7 @@ import com.example.projectlxp.global.dto.PageResponse;
 import com.example.projectlxp.review.dto.ReviewRequestDTO;
 import com.example.projectlxp.review.dto.ReviewResponseDTO;
 import com.example.projectlxp.review.service.ReviewService;
+import com.example.projectlxp.user.entity.User;
 
 import lombok.RequiredArgsConstructor;
 
@@ -42,13 +43,10 @@ public class ReviewController {
     public BaseResponse<ReviewResponseDTO> createReview(
             @PathVariable Long courseId,
             @Valid @RequestBody ReviewRequestDTO requestDTO,
-
-            // Security 대신 '1번 유저'가 썼다고 가정하고 임시 ID를 받음
-            // (나중에 Security 적용되면 이 파라미터는 @AuthenticationPrincipal User user로 변경됨)
-            @RequestParam(defaultValue = "1") Long tempUserId) {
+            @AuthenticationPrincipal User user) {
 
         ReviewResponseDTO responseDTO =
-                reviewService.createReview(courseId, requestDTO, tempUserId);
+                reviewService.createReview(courseId, requestDTO, user.getId());
 
         return BaseResponse.success(responseDTO);
     }
@@ -56,10 +54,8 @@ public class ReviewController {
     // 리뷰 삭제
     @DeleteMapping("/{reviewId}")
     public BaseResponse<Void> deleteReview(
-            @PathVariable Long reviewId,
-            @RequestParam(defaultValue = "1") Long tempUserId // (임시) 임시 유저 ID를 받음
-            ) {
-        reviewService.deleteReview(reviewId, tempUserId);
+            @PathVariable Long reviewId, @AuthenticationPrincipal User user) {
+        reviewService.deleteReview(reviewId, user.getId());
         return BaseResponse.success(null);
     }
 
@@ -68,11 +64,10 @@ public class ReviewController {
     public BaseResponse<ReviewResponseDTO> updateReview(
             @PathVariable Long reviewId,
             @Valid @RequestBody ReviewRequestDTO requestDTO,
-            // (임시) '본인 확인'을 위한 유저 ID
-            @RequestParam(defaultValue = "1") Long tempUserId) {
+            @AuthenticationPrincipal User user) {
 
         ReviewResponseDTO responseDTO =
-                reviewService.updateReview(reviewId, requestDTO, tempUserId);
+                reviewService.updateReview(reviewId, requestDTO, user.getId());
 
         return BaseResponse.success(responseDTO);
     }

--- a/src/main/java/com/example/projectlxp/review/controller/ReviewController.java
+++ b/src/main/java/com/example/projectlxp/review/controller/ReviewController.java
@@ -5,7 +5,6 @@ import java.util.List;
 import jakarta.validation.Valid;
 
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -15,12 +14,12 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.example.projectlxp.global.annotation.CurrentUserId;
 import com.example.projectlxp.global.dto.BaseResponse;
 import com.example.projectlxp.global.dto.PageResponse;
 import com.example.projectlxp.review.dto.ReviewRequestDTO;
 import com.example.projectlxp.review.dto.ReviewResponseDTO;
 import com.example.projectlxp.review.service.ReviewService;
-import com.example.projectlxp.user.entity.User;
 
 import lombok.RequiredArgsConstructor;
 
@@ -43,10 +42,9 @@ public class ReviewController {
     public BaseResponse<ReviewResponseDTO> createReview(
             @PathVariable Long courseId,
             @Valid @RequestBody ReviewRequestDTO requestDTO,
-            @AuthenticationPrincipal User user) {
+            @CurrentUserId Long userId) {
 
-        ReviewResponseDTO responseDTO =
-                reviewService.createReview(courseId, requestDTO, user.getId());
+        ReviewResponseDTO responseDTO = reviewService.createReview(courseId, requestDTO, userId);
 
         return BaseResponse.success(responseDTO);
     }
@@ -54,8 +52,8 @@ public class ReviewController {
     // 리뷰 삭제
     @DeleteMapping("/{reviewId}")
     public BaseResponse<Void> deleteReview(
-            @PathVariable Long reviewId, @AuthenticationPrincipal User user) {
-        reviewService.deleteReview(reviewId, user.getId());
+            @PathVariable Long reviewId, @CurrentUserId Long userId) {
+        reviewService.deleteReview(reviewId, userId);
         return BaseResponse.success(null);
     }
 
@@ -64,10 +62,9 @@ public class ReviewController {
     public BaseResponse<ReviewResponseDTO> updateReview(
             @PathVariable Long reviewId,
             @Valid @RequestBody ReviewRequestDTO requestDTO,
-            @AuthenticationPrincipal User user) {
+            @CurrentUserId Long userId) {
 
-        ReviewResponseDTO responseDTO =
-                reviewService.updateReview(reviewId, requestDTO, user.getId());
+        ReviewResponseDTO responseDTO = reviewService.updateReview(reviewId, requestDTO, userId);
 
         return BaseResponse.success(responseDTO);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,4 +3,3 @@ spring:
     name: LXP-Project
   profiles:
     active: local
-

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,3 +3,4 @@ spring:
     name: LXP-Project
   profiles:
     active: local
+


### PR DESCRIPTION
## ❗️ 이슈 번호
Closes #84 

## 📝 작업 내용
ReviewController에서 사용하던 임시 @RequestParam 파라미터 제거 후 @AuthenticationPrincipal User user로 모두 변경하여 실제 로그인 사용자의 Id를 서비스에 전달하도록 수정 했습니다.
## 💭 주의 사항
로컬 테스트 완료
./gradlew clean build 명령어 실행 후 success 확인.

## 💡 리뷰 포인트
Service 코드는 변경 없이 Controller 코드의 시그니처만 수정 했습니다.
