### PR TITLE
[FIX] 사용자가 deleted 되어있지 않은 경우에도 알 수 없음으로 뜨는 오류 해결

### DIFF
--- a/src/main/java/com/example/projectlxp/course/dto/CourseDTO.java
+++ b/src/main/java/com/example/projectlxp/course/dto/CourseDTO.java
@@ -1,9 +1,5 @@
 package com.example.projectlxp.course.dto;
 
-import static java.util.Objects.isNull;
-
-import org.hibernate.Hibernate;
-
 import com.example.projectlxp.category.entity.Category;
 import com.example.projectlxp.course.entity.Course;
 import com.example.projectlxp.user.entity.User;
@@ -22,10 +18,11 @@ public record CourseDTO(
     public record UserDTO(Long id, String name, String email) {
 
         public static UserDTO of(User user) {
-            if (!Hibernate.isInitialized(user) || isNull(user)) {
+            try {
+                return new UserDTO(user.getId(), user.getName(), user.getEmail());
+            } catch (Exception ex) {
                 return new UserDTO(null, "알 수 없음", null);
             }
-            return new UserDTO(user.getId(), user.getName(), user.getEmail());
         }
     }
 


### PR DESCRIPTION
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->

## ❗️ 이슈 번호
Closes 

## 📝 작업 내용

1. 데이터는 가져왔다 (DB 레벨)

- LEFT JOIN을 사용하면, 데이터베이스 쿼리는 Course와 User의 모든 요청 필드를 한 번에 가져옵니다. 데이터는 애플리케이션의 메모리에 있습니다.

2. 초기화 상태는 LAZY (Hibernate 레벨)

- Course 엔티티의 instructor 필드가 FetchType.LAZY로 설정되어 있기 때문에, Hibernate는 다음과 같이 처리합니다.

- course.getInstructor()에는 실제 User 객체가 아닌 User 프록시 객체를 할당합니다.

- 이 프록시 객체는 조인 결과로 가져온 데이터를 내부적으로 보유하고 있습니다.

- 하지만 Hibernate의 내부 플래그는 여전히 이 객체를 **"지연 로딩 대기 상태"**로 표시합니다. 즉, Hibernate.isInitialized(user)는 false입니다.

## 💭 주의 사항

## 💡 리뷰 포인트
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->
